### PR TITLE
Update in-meeting app to fix the 'npm start' bug on WSL

### DIFF
--- a/in-meeting-app/bot/package.json
+++ b/in-meeting-app/bot/package.json
@@ -4,7 +4,7 @@
     "description": "The API server for a Teams tab app",
     "main": "app.js",
     "scripts": {
-        "start:local": "CROSS-ENV NODE_ENV=development.local node ./index.js",
+        "start:local": "cross-env NODE_ENV=development.local node ./index.js",
         "start": "node ./index.js",
         "watch": "nodemon ./index.js"
     },


### PR DESCRIPTION
BUG https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/9978317
CROSS-ENV command not found in WSL, change to cross-env to fix it.