### PR TITLE
fix: skip join view when local debug

### DIFF
--- a/share-now/.vscode/launch.json
+++ b/share-now/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Launch Remote (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 1
@@ -15,7 +15,7 @@
             "name": "Launch Remote (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 2
@@ -25,7 +25,7 @@
             "name": "Start and Attach to Frontend (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "preLaunchTask": "Start Frontend",
             "cascadeTerminateToConfigurations": [
                 "Start and Attach to Bot",
@@ -40,7 +40,7 @@
             "name": "Start and Attach to Frontend (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "preLaunchTask": "Start Frontend",
             "cascadeTerminateToConfigurations": [
                 "Start and Attach to Bot",

--- a/todo-list-with-Azure-backend/.vscode/launch.json
+++ b/todo-list-with-Azure-backend/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Launch Remote (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 1
@@ -15,7 +15,7 @@
             "name": "Launch Remote (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 2
@@ -25,7 +25,7 @@
             "name": "Start and Attach to Frontend (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "preLaunchTask": "Start Frontend",
             "cascadeTerminateToConfigurations": [
                 "Start and Attach to Backend"
@@ -39,7 +39,7 @@
             "name": "Start and Attach to Frontend (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
+            "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "preLaunchTask": "Start Frontend",
             "cascadeTerminateToConfigurations": [
                 "Start and Attach to Backend"


### PR DESCRIPTION
Add `&webjoin=true` to launch url to **skip** the selector page:
![image](https://user-images.githubusercontent.com/7642967/119212776-2377c780-baed-11eb-90cc-ca7b2eb51185.png)
