### PR TITLE
fix(share-now): workaround dependency conflict issue

### DIFF
--- a/share-now/tabs/package.json
+++ b/share-now/tabs/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"private": true,
 	"dependencies": {
+		"@azure/core-tracing": "1.0.0-preview.13",
 		"@fluentui/react": "^7.115.4",
 		"@fluentui/react-icons-northstar": "^0.49.0",
 		"@fluentui/react-northstar": "^0.49.0",


### PR DESCRIPTION
Will revoke the change after we resolve the bug in Teams Toolkit.