### PR TITLE
docs: add session storage notice

### DIFF
--- a/hello-world-tab-with-backend/README.md
+++ b/hello-world-tab-with-backend/README.md
@@ -6,6 +6,7 @@
 >
 > This warning will be removed when the samples are ready for production.
 
+> Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 
 Hello World Tab with Backend shows you how to build a tab app with an Azure Function as backend, how to get user login information with SSO and how to call Azure Function from frontend tab.

--- a/hello-world-tab-with-backend/tabs/src/components/sample/lib/useGraph.ts
+++ b/hello-world-tab-with-backend/tabs/src/components/sample/lib/useGraph.ts
@@ -10,6 +10,7 @@ export function useGraph<T>(
   const initial = useData(async () => {
     try {
       const credential = new TeamsUserCredential();
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     } catch (err: unknown) {
@@ -25,6 +26,7 @@ export function useGraph<T>(
     async () => {
       const credential = new TeamsUserCredential();
       await credential.login(scope);
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },

--- a/hello-world-tab/README.md
+++ b/hello-world-tab/README.md
@@ -6,6 +6,8 @@
 >
 > This warning will be removed when the samples are ready for production.
 
+> Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
+
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 
 Hello World Tab shows you how to build a tab app and how to get user login information with SSO.

--- a/hello-world-tab/tabs/src/components/sample/lib/useGraph.ts
+++ b/hello-world-tab/tabs/src/components/sample/lib/useGraph.ts
@@ -10,6 +10,7 @@ export function useGraph<T>(
   const initial = useData(async () => {
     try {
       const credential = new TeamsUserCredential();
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     } catch (err: unknown) {
@@ -25,6 +26,7 @@ export function useGraph<T>(
     async () => {
       const credential = new TeamsUserCredential();
       await credential.login(scope);
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },


### PR DESCRIPTION
@zhenyasav , could you help provide the helper link target URL, I will update it in aka service: https://aka.ms/teamsfx-session-storage-notice

Related task:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY21-12.1?workitem=12699312