### PR TITLE
fix: add missing isFromSample property for telemetry

### DIFF
--- a/bot-sso/.fx/configs/projectSettings.json
+++ b/bot-sso/.fx/configs/projectSettings.json
@@ -17,6 +17,7 @@
             "fx-resource-appstudio"
         ]
     },
+    "isFromSample": true,
     "programmingLanguage": "typescript",
     "version": "2.0.0"
 }


### PR DESCRIPTION
This property is added for telemetry to distinguish whether current event is from sample or scratch projects.