### PR TITLE
perf: update sdk version to 0.5.0-rc

### DIFF
--- a/hello-world-tab-with-backend/api/package.json
+++ b/hello-world-tab-with-backend/api/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "@azure/functions": "^1.2.2",
         "@microsoft/microsoft-graph-client": "^3.0.1",
-        "@microsoft/teamsfx": "^0.5.0",
+        "@microsoft/teamsfx": "^0.5.0-rc",
         "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {

--- a/hello-world-tab-with-backend/tabs/package.json
+++ b/hello-world-tab-with-backend/tabs/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
         "@microsoft/teams-js": "^1.9.0",
-        "@microsoft/teamsfx": "^0.5.0",
+        "@microsoft/teamsfx": "^0.5.0-rc",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",
         "msteams-react-base-component": "^3.1.0",

--- a/hello-world-tab/tabs/package.json
+++ b/hello-world-tab/tabs/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
         "@microsoft/teams-js": "^1.9.0",
-        "@microsoft/teamsfx": "^0.5.0",
+        "@microsoft/teamsfx": "^0.5.0-rc",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",
         "msteams-react-base-component": "^3.1.0",

--- a/todo-list-with-Azure-backend-M365/api/package.json
+++ b/todo-list-with-Azure-backend-M365/api/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@azure/functions": "^1.2.2",
-    "@microsoft/teamsfx": "^0.5.0",
+    "@microsoft/teamsfx": "^0.5.0-rc",
     "isomorphic-fetch": "^3.0.0",
     "uuid": "^8.3.2"
   }

--- a/todo-list-with-Azure-backend-M365/tabs/package.json
+++ b/todo-list-with-Azure-backend-M365/tabs/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.51.0",
     "@microsoft/teams-js": "2.0.0-beta.2",
-    "@microsoft/teamsfx": "^0.5.0",
+    "@microsoft/teamsfx": "^0.5.0-rc",
     "axios": "^0.21.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/todo-list-with-Azure-backend/api/package.json
+++ b/todo-list-with-Azure-backend/api/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@azure/functions": "^1.2.2",
-    "@microsoft/teamsfx": "^0.5.0",
+    "@microsoft/teamsfx": "^0.5.0-rc",
     "isomorphic-fetch": "^3.0.0",
     "tedious": "^9.2.1"
   }

--- a/todo-list-with-Azure-backend/tabs/package.json
+++ b/todo-list-with-Azure-backend/tabs/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.51.0",
     "@microsoft/teams-js": "^1.6.0",
-    "@microsoft/teamsfx": "^0.5.0",
+    "@microsoft/teamsfx": "^0.5.0-rc",
     "axios": "^0.21.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Since currently @microsoft/teamsfx v0.5.0 has not yet been released and thus the sample using 0.5.0 will be broken, change the sdk version to v0.5.0-rc so the sample in dev branch is workable.

Consider change sdk version back to 0.5.0 after 0.5.0 release (after Feb. 7th).