### PR TITLE
fix(M365): use latest next teamsfx sdk to work on outlook/office

### DIFF
--- a/todo-list-with-Azure-backend-M365/tabs/package.json
+++ b/todo-list-with-Azure-backend-M365/tabs/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.51.0",
     "@microsoft/teams-js": "2.0.0-beta.2",
-    "@microsoft/teamsfx": "^0.5.0",
+    "@microsoft/teamsfx": "0.5.0-beta.0",
     "axios": "^0.21.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/todo-list-with-Azure-backend-M365/tabs/package.json
+++ b/todo-list-with-Azure-backend-M365/tabs/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.51.0",
     "@microsoft/teams-js": "2.0.0-beta.2",
-    "@microsoft/teamsfx": "0.5.0-beta.0",
+    "@microsoft/teamsfx": "0.5.0-beta.2",
     "axios": "^0.21.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
The M365 sample should use next(tag) teamsfx sdk to not only work on Teams.