### PR TITLE
feat: add notification storage implemenation sample

### DIFF
--- a/adaptive-card-notification/README.md
+++ b/adaptive-card-notification/README.md
@@ -64,7 +64,7 @@ Adaptive Card Notification provides an easy way to send notification in Teams. T
 ## (Optional) Use Azure Blob Storage to persist notification connections
 This sample provides an implementation of `NotificationTargetStorage` at `bot/src/storage/blobsStorage.ts`, which connects to Azure Blob Storage to persist notification connections.
 
-To try it, uncomment the line 16 of `bot/src/internal/initialize.ts`, then enter your own connection string and container name.
+To try it, uncomment the `notification.storage` settings of your bot in `bot/src/internal/initialize.ts`, then enter your own connection string and container name.
 
 ``` typescript
 ...

--- a/adaptive-card-notification/README.md
+++ b/adaptive-card-notification/README.md
@@ -61,6 +61,20 @@ Adaptive Card Notification provides an easy way to send notification in Teams. T
 - The mention adaptive card template is in [notification-mention.json](bot/src/adaptiveCards/notification-mention.json). For more details of the adaptive card schema, you can refer to https://docs.microsoft.com/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cconnector-html#mention-support-within-adaptive-cards.
   ![mention](./images/mention.jpg)
 
+## (Optional) Use Azure Blob Storage to persist notification connections
+This sample provides an implementation of `NotificationTargetStorage` at `bot/src/storage/blobsStorage.ts`, which connects to Azure Blob Storage to persist notification connections.
+
+To try it, uncomment the line 16 of `bot/src/internal/initialize.ts`, then enter your own connection string and container name.
+
+``` typescript
+...
+  notification: {
+    enabled: true,
+    storage: new BlobsStorage("{your-connection-string}", "{your-container-name}"),
+  },
+...
+```
+
 ## Architecture
 - The notification is hosted on [Azure Function](https://docs.microsoft.com/en-us/azure/azure-functions/) for triggering a notification.
 - The Backend server is hosted on [Azure Function](https://docs.microsoft.com/en-us/azure/azure-functions/) for receiving bot messages.

--- a/adaptive-card-notification/bot/package.json
+++ b/adaptive-card-notification/bot/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.9.0",
     "@microsoft/adaptivecards-tools": "^0.1.3",
     "@microsoft/teamsfx": "0.6.3-alpha.768a76f6e.0",
     "botbuilder": "~4.15.0"

--- a/adaptive-card-notification/bot/src/internal/initialize.ts
+++ b/adaptive-card-notification/bot/src/internal/initialize.ts
@@ -13,6 +13,6 @@ export const bot = new ConversationBot({
   notification: {
     enabled: true,
     // uncomment following line to use your own blob storage
-    //storage: new BlobsStorage("{your-connection-string}", "{your-container-name}"),
+    // storage: new BlobsStorage("{your-connection-string}", "{your-container-name}"),
   },
 });

--- a/adaptive-card-notification/bot/src/internal/initialize.ts
+++ b/adaptive-card-notification/bot/src/internal/initialize.ts
@@ -1,4 +1,5 @@
 import { ConversationBot } from "@microsoft/teamsfx";
+import { BlobsStorage } from "../storage/blobsStorage";
 
 // Create bot.
 export const bot = new ConversationBot({
@@ -11,5 +12,7 @@ export const bot = new ConversationBot({
   // Enable notification
   notification: {
     enabled: true,
+    // uncomment following line to use your own blob storage
+    //storage: new BlobsStorage("{your-connection-string}", "{your-container-name}"),
   },
 });

--- a/adaptive-card-notification/bot/src/storage/blobsStorage.ts
+++ b/adaptive-card-notification/bot/src/storage/blobsStorage.ts
@@ -1,0 +1,110 @@
+import { ContainerClient } from "@azure/storage-blob";
+import { NotificationTargetStorage } from "@microsoft/teamsfx";
+
+// A sample implementation to use Azure Blob Storage as notification target storage
+export class BlobsStorage implements NotificationTargetStorage {
+  private readonly client: ContainerClient;
+  private initializePromise?: Promise<unknown>;
+
+  // This implementation uses connection string and container name to connect Azure Blob Storage
+  constructor(connectionString: string, containerName: string) {
+    this.client = new ContainerClient(connectionString, containerName);
+  }
+
+  async read(key: string): Promise<{ [key: string]: unknown; }> {
+    await this.initialize();
+
+    const blobName = this.normalizeKey(key);
+
+    try {
+      const stream = await this.client.getBlobClient(blobName).download();
+      const content = await this.streamToBuffer(stream.readableStreamBody);
+      return JSON.parse(content.toString());
+    } catch (error) {
+      if (error.statusCode === 404) {
+        return undefined;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async list(): Promise<{ [key: string]: unknown; }[]> {
+    await this.initialize();
+
+    const result = [];
+    const blobsIter = this.client.listBlobsFlat();
+    let blobItem = await blobsIter.next();
+    while (!blobItem.done) {
+      try {
+        const stream = await this.client.getBlockBlobClient(blobItem.value.name).download();
+        const content = await this.streamToBuffer(stream.readableStreamBody);
+        result.push(JSON.parse(content.toString()));
+      } catch (error) {
+        if (error.statusCode !== 404) {
+          throw error;
+        }
+      }
+      blobItem = await blobsIter.next();
+    }
+
+    return result;
+  }
+
+  async write(key: string, object: { [key: string]: unknown; }): Promise<void> {
+    await this.initialize();
+
+    const blobName = this.normalizeKey(key);
+
+    try {
+      const content = JSON.stringify(object);
+      await this.client.getBlockBlobClient(blobName).upload(content, Buffer.byteLength(content));
+    } catch (error) {
+      if (error.statusCode !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.initialize();
+
+    const blobName = this.normalizeKey(key);
+
+    try {
+      await this.client.getBlobClient(blobName).delete();
+    } catch (error) {
+      if (error.statusCode !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  // Initialize to create container if not exists yet
+  private initialize(): Promise<unknown> {
+    if (!this.initializePromise) {
+      this.initializePromise = this.client.createIfNotExists();
+    }
+
+    return this.initializePromise;
+  }
+
+  // A help method to normalize key to meet Azure Blob naming requirement
+  private normalizeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+
+  // A helper method used to read a Node.js readable stream into a Buffer
+  private streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on("data", (data) => {
+        chunks.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+      });
+      stream.on("end", () => {
+        resolve(Buffer.concat(chunks));
+      });
+      stream.on("error", reject);
+    });
+  }
+}


### PR DESCRIPTION
This adds a sample implementation of `NotificationTargetStorage` to persist to Azure Blob Storage.
Since we haven't provided such implementation from our SDK, this is the sample that we can provide to developers to try Azure Blob Storage for production environments.