### PR TITLE
chore: rename messaging extension to message extension

### DIFF
--- a/NPM-search-connector-M365/README.md
+++ b/NPM-search-connector-M365/README.md
@@ -6,7 +6,7 @@
 >  
 > This warning will be removed when the samples are ready for production.
 
-NPM Search Connector is a Messaging Extension that allows you to perform a quick search to NPM Registry for a package and insert package details into conversations for sharing with your co-workers. The front end is built with Adaptive Cards to render NPM package details and the backend is an Azure Bot Service handling search queries and communication between the server workload and the clients, including Teams and Outlook (Web Client).
+NPM Search Connector is a Message Extension that allows you to perform a quick search to NPM Registry for a package and insert package details into conversations for sharing with your co-workers. The front end is built with Adaptive Cards to render NPM package details and the backend is an Azure Bot Service handling search queries and communication between the server workload and the clients, including Teams and Outlook (Web Client).
 
 ![Npm Search Connector](images/npm-search-connector-M365.gif)
 
@@ -34,17 +34,17 @@ NPM Search Connector is a Messaging Extension that allows you to perform a quick
   ![Install in Teams VSC Local](./images/install-in-teams-vsc-local.png)
 
 ## Use the app in Teams
-To trigger the messaging extension in Teams, there are multiple entry points:
-- `@mention` your messaging extension, from the search box area.
+To trigger the message extension in Teams, there are multiple entry points:
+- `@mention` your message extension, from the search box area.
   ![At Bot from Search](./images/at-bot-from-search.png)
-- `@mention` your messaging extension from the compose message area.
+- `@mention` your message extension from the compose message area.
   ![At Bot in Message](./images/at-bot-in-message.png)
-- Click the `...` under compose message area, find your messaging extension.
+- Click the `...` under compose message area, find your message extension.
   ![Open Bot via Three Dot](./images/open-bot-via-three-dot.png)
 
 ## Use the app in Outlook Web Client
-To trigger the messaging extension in Outlook:
-- Click the "More apps" icon under compose email area, find your messaging extension.
+To trigger the message extension in Outlook:
+- Click the "More apps" icon under compose email area, find your message extension.
   ![Open Bot in Outlook](./images/open-bot-in-outlook.png)
 
 ## Architecture

--- a/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/IKnowledgeBaseSearchService.cs
+++ b/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/IKnowledgeBaseSearchService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
     public interface IKnowledgeBaseSearchService
     {
         /// <summary>
-        /// This method gives search result(Knowledgebase QnA pairs) based on search query for messaging extension.
+        /// This method gives search result(Knowledgebase QnA pairs) based on search query for message extension.
         /// </summary>
         /// <param name="searchQuery">Search query for question and answer pair.</param>
         /// <returns>Search result list.</returns>

--- a/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/KnowledgeBaseSearchService.cs
+++ b/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/KnowledgeBaseSearchService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
         }
 
         /// <summary>
-        /// This method gives search result(Knowledgebase QnA pairs) based on search query for messaging extension.
+        /// This method gives search result(Knowledgebase QnA pairs) based on search query for message extension.
         /// </summary>
         /// <param name="searchQuery">Search query for question and answer pair.</param>
         /// <returns>Search result list.</returns>

--- a/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/SearchService.cs
+++ b/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/SearchService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
         private const string TicketsIndexerName = "tickets-indexer";
         private const string TicketsDataSourceName = "tickets-storage";
 
-        // Default to 25 results, same as page size of a messaging extension query
+        // Default to 25 results, same as page size of a message extension query
         private const int DefaultSearchResultCount = 25;
 
         private readonly Lazy<Task> initializeTask;
@@ -124,7 +124,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
         {
             try
             {
-                await this.ticketProvider.GetTicketAsync(string.Empty); // When there is no ticket created by end user and messaging extension is open by SME, table initialization is required here before creating search index or datasource or indexer.
+                await this.ticketProvider.GetTicketAsync(string.Empty); // When there is no ticket created by end user and message extension is open by SME, table initialization is required here before creating search index or datasource or indexer.
                 await this.CreateIndexAsync().ConfigureAwait(false);
                 await this.CreateDataSourceAsync(storageConnectionString).ConfigureAwait(false);
                 await this.CreateIndexerAsync().ConfigureAwait(false);

--- a/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/TicketsProvider.cs
+++ b/faq-plus/configapp/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/TicketsProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
         /// <returns><see cref="Task"/> Already saved entity detail.</returns>
         public async Task<TicketEntity> GetTicketAsync(string ticketId)
         {
-            await this.EnsureInitializedAsync().ConfigureAwait(false); // When there is no ticket created by end user and messaging extension is open by SME, table initialization is required before creating search index or datasource or indexer.
+            await this.EnsureInitializedAsync().ConfigureAwait(false); // When there is no ticket created by end user and message extension is open by SME, table initialization is required before creating search index or datasource or indexer.
             if (string.IsNullOrEmpty(ticketId))
             {
                 return null;

--- a/share-now/README.md
+++ b/share-now/README.md
@@ -109,10 +109,10 @@ To debug the project, you will need to configure an Azure SQL Database to be use
 
 ![Tab App Flow](images/app.png)
 
-This sample app consists of a personal tab and a messaging extension used to manage, search and share posts.
+This sample app consists of a personal tab and a message extension used to manage, search and share posts.
 - The frontend is a react tab app hosted on [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
 - The Backend server is hosted on [Azure Function](https://docs.microsoft.com/en-us/azure/azure-functions/) for managing posts in the tab app.
-- The messaging extension is hosted on [Azure Web App](https://docs.microsoft.com/en-us/azure/app-service/overview) for searching and sharing posts.
+- The message extension is hosted on [Azure Web App](https://docs.microsoft.com/en-us/azure/app-service/overview) for searching and sharing posts.
 - The [Azure SQL DB](https://docs.microsoft.com/en-us/azure/azure-sql/) used to persist data.
 
 ### Code structure


### PR DESCRIPTION
Update naming for samples

Still need to sync with Teams team about the interface which contains the naming 'messaging extension'
Like 'handleTeamsMessagingExtensionQuery'