### PR TITLE
fix: support npm lower than 6

### DIFF
--- a/hello-world-tab-with-backend/tabs/package.json
+++ b/hello-world-tab-with-backend/tabs/package.json
@@ -12,6 +12,7 @@
     "@microsoft/teamsfx": "^1.0.0",
     "@microsoft/teamsfx-react": "^1.0.0",
     "axios": "^0.21.1",
+    "msteams-react-base-component": "^3.1.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.1.2",

--- a/hello-world-tab/tabs/package.json
+++ b/hello-world-tab/tabs/package.json
@@ -12,6 +12,7 @@
     "@microsoft/teamsfx": "^1.0.0",
     "@microsoft/teamsfx-react": "^1.0.0",
     "axios": "^0.21.1",
+    "msteams-react-base-component": "^3.1.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION
msteams-react-base-component is a peer dependency of @microsoft/teamsfx-react. npm@6 does not install peer dependency so these sample may fail to build with npm@6.