### PR TITLE
chore: change the pkg to a release pkg

### DIFF
--- a/share-now/api/extensions.csproj
+++ b/share-now/api/extensions.csproj
@@ -5,7 +5,7 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="TeamsDevFunction" Version="0.1.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.TeamsFx" Version="1.0.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
   </ItemGroup>
 </Project>

--- a/share-now/tabs/.eslintrc
+++ b/share-now/tabs/.eslintrc
@@ -8,8 +8,5 @@
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended"
-    ],
-    "rules": {
-      "indent": [2, 2]
-    }
+    ]
 }

--- a/share-now/tabs/package.json
+++ b/share-now/tabs/package.json
@@ -23,6 +23,10 @@
     "tslib": "^2.0.0",
     "typescript": "^4.2.4"
   },
+  "resolutions": {
+    "@types/react": "16.8.0",
+    "@types/react-dom": "16.8.0"
+  },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
     "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",


### PR DESCRIPTION
1. support node 14 and fix tab npm run build error
2. modify the api pkg to the function 1.0.0 stable version