### PR TITLE
fix(graph-connector): 'Attach to Backend' does not stop after closing browser in local debug

### DIFF
--- a/graph-connector-app/.vscode/launch.json
+++ b/graph-connector-app/.vscode/launch.json
@@ -26,6 +26,9 @@
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
             "presentation": {
                 "group": "all",
                 "hidden": true
@@ -36,6 +39,9 @@
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
             "presentation": {
                 "group": "all",
                 "hidden": true


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14524997