### PR TITLE
chore(m365): add resource name suffix

### DIFF
--- a/NPM-search-connector-M365/.fx/configs/azure.parameters.dev.json
+++ b/NPM-search-connector-M365/.fx/configs/azure.parameters.dev.json
@@ -4,7 +4,7 @@
     "parameters": {
         "provisionParameters": {
             "value": {
-                "resourceBaseName": "npmsearchcdev",
+                "resourceBaseName": "npmsearchcdev{{state.solution.resourceNameSuffix}}",
                 "botAadAppClientId": "{{state.fx-resource-bot.botId}}",
                 "botAadAppClientSecret": "{{state.fx-resource-bot.botPassword}}"
             }


### PR DESCRIPTION
Seems that there is some error on the merge from ga/release to dev before, so let me add the resource name suffix again.

The change for todo-list-with-Azure-backend-M365 is in https://github.com/OfficeDev/TeamsFx-Samples/pull/431.