### PR TITLE
fix(graph-connector): workaround fix to update 'double' type to 'string'

### DIFF
--- a/graph-connector-app/README.md
+++ b/graph-connector-app/README.md
@@ -65,6 +65,8 @@ This sample app showcases how to build custom Graph Connector with Azure Functio
 
     > In addition, you could go to [Microsoft 365 admin center](https://admin.microsoft.com/Adminportal/Home#/MicrosoftSearch/connectors) to see the status of custom Graph Connector.
 
+    > If you meet with error of `400` status code, you could try to delete the connection in [Microsoft 365 admin center](https://admin.microsoft.com/Adminportal/Home#/MicrosoftSearch/connectors) and ingest data again.
+
     ![Ingest](images/ingest.png)
 
 1. You could try to query data from custom Graph Connector.

--- a/graph-connector-app/api/data/index.ts
+++ b/graph-connector-app/api/data/index.ts
@@ -72,7 +72,7 @@ export default async function run(
             "partNumber": Number(item.PartNumber),
             "name": item.Name,
             "description": item.Description,
-            "price": Number(item.Price),
+            "price": item.Price,
             "inventory": Number(item.Inventory),
             "appliances": item.Appliances.split(";"),
             "appliances@odata.type": "Collection(String)"

--- a/graph-connector-app/api/schema/index.ts
+++ b/graph-connector-app/api/schema/index.ts
@@ -84,7 +84,7 @@ export default async function run(
           },
           {
             "name": "price",
-            "type": "double",
+            "type": "string",
             "isSearchable": false,
             "isRetrievable": true,
             "isQueryable": true,


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14938222

This issue is caused by a regression in Graph Connector. 'double' type in schema would be affected if you are using JS. See more in https://o365exchange.visualstudio.com/defaultcollection/O365%20Core/_workitems/edit/2931419

For quick workaround, update 'double' type to 'string' type.