### PR TITLE
Fix a bad link and parameters for one productivity hub

### DIFF
--- a/graph-toolkit-one-productivity-hub/.fx/configs/azure.parameters.dev.json
+++ b/graph-toolkit-one-productivity-hub/.fx/configs/azure.parameters.dev.json
@@ -4,7 +4,7 @@
   "parameters": {
     "provisionParameters": {
       "value": {
-        "resourceBaseName": "oneproductdev289bec",
+        "resourceBaseName": "oneproductdev{{state.solution.resourceNameSuffix}}",
         "m365ClientId": "{{state.fx-resource-aad-app-for-teams.clientId}}",
         "m365ClientSecret": "{{state.fx-resource-aad-app-for-teams.clientSecret}}",
         "m365TenantId": "{{state.fx-resource-aad-app-for-teams.tenantId}}",

--- a/graph-toolkit-one-productivity-hub/README.md
+++ b/graph-toolkit-one-productivity-hub/README.md
@@ -86,7 +86,7 @@ One Productivity Hub sample shows you how to build a tab for viewing your calend
 
 - You can check app configuration and environment information in: [.fx](.fx)
 - You will find frontend code in: [tabs/src/components](tabs/src/components)
-- You will find authentication code in: [public](public)
+- You will find authentication code in: [public](tabs/public/)
 
 ## Code of Conduct
 


### PR DESCRIPTION
fix: wrong link in README.md(code of conduct: public)
fix: change fixed resource name suffix to dynamic in .fx/azure.parameters.dev.json