### PR TITLE
feat(comment): add app credential in Azure function as comments 

### DIFF
--- a/hello-world-tab-with-backend/api/getUserProfile/index.ts
+++ b/hello-world-tab-with-backend/api/getUserProfile/index.ts
@@ -124,7 +124,7 @@ export default async function run(
     };
   }
 
-  // Create a graph client to access user's Microsoft 365 data after user has consented. 
+  // Create a graph client with default scope to access user's Microsoft 365 data after user has consented. 
   try {
     const graphClient: Client = createMicrosoftGraphClient(teamsfx_app, [".default"]);
   


### PR DESCRIPTION
1. We seperate the Azure function response info into 2 parts: one is get by user credential, and the other is get by app credential. 
2. Users can learn to use two different auth flows to call graph api in this sample.