### PR TITLE
Update AAD permissions consented to app

### DIFF
--- a/graph-connector-app/README.md
+++ b/graph-connector-app/README.md
@@ -43,7 +43,7 @@ This sample app showcases how to build custom Graph Connector with Azure Functio
 
     ![Consent](images/consent.png)
 
-1. Before ingesting data, you need to do 'Admin Consent' with 'ExternalItem.ReadWrite.All' application permission for your AAD App in Azure Portal.
+1. Before ingesting data, you need to do 'Admin Consent' with 'ExternalConnection.ReadWrite.OwnedBy' and 'ExternalItem.ReadWrite.OwnedBy' application permissions for your AAD App in Azure Portal.
 
     1. Find the client id in `.fx\states\state.xxx.json` file (e.g. `state.local.json` for local environment, `state.dev.json` for dev environment).
 

--- a/graph-connector-app/api/connection/index.ts
+++ b/graph-connector-app/api/connection/index.ts
@@ -66,7 +66,7 @@ export default async function run(
       context.log.error(e);
       let error = "Failed to create a connection for Graph connector: " + e.toString();
       if (e?.statusCode === 401) {
-        error += " -- Please make sure you have done 'Admin Consent' with 'ExternalItem.ReadWrite.All' application permission for your AAD App";
+        error += " -- Please make sure you have done 'Admin Consent' with 'ExternalConnection.ReadWrite.OwnedBy' and 'ExternalItem.ReadWrite.OwnedBy' application permissions for your AAD App";
       }
       return {
         status: e?.statusCode ?? 500,

--- a/graph-connector-app/tabs/src/components/sample/Ingest.tsx
+++ b/graph-connector-app/tabs/src/components/sample/Ingest.tsx
@@ -78,7 +78,7 @@ export function Ingest() {
     <div>
       <h2>2. Ingest Sample Data into Graph Connector</h2>
       <p>An Azure Functions app is running. Click below button to ingest data from the <a href="https://github.com/microsoftgraph/msgraph-search-connector-sample/blob/main/PartsInventoryConnector/ApplianceParts.csv" target="_blank" rel="noreferrer">CSV file</a>.</p>
-      <p><strong>Note: before ingesting data, you need to do 'Admin Consent' with 'ExternalItem.ReadWrite.All' application permission for your AAD App in Azure Portal.</strong></p>
+      <p><strong>Note: before ingesting data, you need to do 'Admin Consent' with 'ExternalConnection.ReadWrite.OwnedBy' and 'ExternalItem.ReadWrite.OwnedBy' application permissions for your AAD App in Azure Portal.</strong></p>
       <Button primary content="Ingest Data" disabled={loading} onClick={ingestData} />
       {loading && (
         <Loader />

--- a/graph-connector-app/templates/appPackage/aad.template.json
+++ b/graph-connector-app/templates/appPackage/aad.template.json
@@ -21,7 +21,11 @@
             "resourceAppId": "Microsoft Graph",
             "resourceAccess": [
                 {
-                    "id": "ExternalItem.ReadWrite.All",
+                    "id": "ExternalConnection.ReadWrite.OwnedBy",
+                    "type": "Role"
+                },
+                {
+                    "id": "ExternalItem.ReadWrite.OwnedBy",
                     "type": "Role"
                 },
                 {


### PR DESCRIPTION
Updating permissions for Azure AD consent of Graph connector app to use more fine-grained ".OwnedBy" versions instead of ".All".