### PR TITLE
fix: sync botbuilder version with SDK

### DIFF
--- a/adaptive-card-notification/bot/package.json
+++ b/adaptive-card-notification/bot/package.json
@@ -22,7 +22,7 @@
     "@azure/storage-blob": "^12.9.0",
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "@microsoft/teamsfx": "^1.0.0",
-    "botbuilder": "~4.15.0"
+    "botbuilder": "^4.15.0"
   },
   "devDependencies": {
     "@azure/functions": "^1.2.3",


### PR DESCRIPTION
TeamsFx SDK depends on botbuilder: >=4.15.0<5.0.0, while the latest version of botbuilder is 4.17.0. Those bot templates depend on ~4.15.0 will face the compile error caused by the unmatched version.
Therefore, update the affected samples' package.json to sync the version with SDK.

```
node_modules/@microsoft/teamsfx/types/teamsfx.d.ts:424:15 - error TS2416: Property 'onEndDialog' in type 'BotSsoExecutionDialog' is not assignable to the same property in base type 'ComponentDialog<{}>'.
  Type '(context: TurnContext) => Promise<void>' is not assignable to type '(_context: TurnContext, _instance: DialogInstance<any>, _reason: DialogReason) => Promise<void>'.
    Types of parameters 'context' and '_context' are incompatible.
      Type 'import("<path>/bot/node_modules/botbuilder-dialogs/node_modules/botbuilder-core/lib/turnContext").TurnContext' is not assignable to type 'import("<path>/bot/node_modules/botbuilder-core/lib/turnContext").TurnContext'.
        Types have separate declarations of a private property '_adapter'.

424     protected onEndDialog(context: TurnContext): Promise<void>;
```

Repro:
1. Create a project starting from sample.
2. Select adaptive card notification bot.
3. update sdk using rc version: "@microsoft/teamsfx": "1.2.0-rc.0".
4. cd bot && npm install && tsc.