### PR TITLE
Use DataInterface to make it easier for readers to understand

### DIFF
--- a/hello-world-bot/bot/teamsBot.ts
+++ b/hello-world-bot/bot/teamsBot.ts
@@ -17,7 +17,7 @@ export interface DataInterface {
 
 export class TeamsBot extends TeamsActivityHandler {
   // record the likeCount
-  likeCountObj: { likeCount: number };
+  likeCountObj: DataInterface;
 
   constructor() {
     super();


### PR DESCRIPTION
Use DataInterface to make it clear to readers that `likeCountObj` is an object of `interface DataInterface`