### PR TITLE
fix: fix type error

### DIFF
--- a/stocks-update-notification-bot/bot/src/timerTrigger.ts
+++ b/stocks-update-notification-bot/bot/src/timerTrigger.ts
@@ -78,7 +78,7 @@ const sendCard =
   <T extends object>(target: TeamsBotInstallation) =>
     (ac: typeof AdaptiveCards) =>
       (template: object) =>
-        (quote: GlobalQuote): Promise<void> =>
+        (quote: GlobalQuote): Promise<any> =>
           target.sendAdaptiveCard(ac.declare<T>(template).render(quote as T));
 
 const handleError =


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15580856/
`sendAdaptiveCard` may return `void` or `MessageResponse`, depending on SDK version. So use `any` to keep compatibility.