### PR TITLE
Remove preview warnings

### DIFF
--- a/NPM-search-connector-M365/README.md
+++ b/NPM-search-connector-M365/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Npm Search Connector Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 NPM Search Connector is a Message Extension that allows you to perform a quick search to NPM Registry for a package and insert package details into conversations for sharing with your co-workers. The front end is built with Adaptive Cards to render NPM package details and the backend is an Azure Bot Service handling search queries and communication between the server workload and the clients, including Teams and Outlook (Web Client).
 
 ![Npm Search Connector](images/npm-search-connector-M365.gif)

--- a/adaptive-card-notification/README.md
+++ b/adaptive-card-notification/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Adaptive Card Notification Sample (Azure)
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 Adaptive Card Notification provides an easy way to send notification in Teams. The front end is built with Adaptive Cards to render notification details, the bot framework service is an Azure Bot Service handling search queries and communication between the server workload and the client and the backend is hosted in Azure Functions providing notification trigger and message handler.
 
 ![Adaptive Card Notification Overview](images/adaptivecard.gif)

--- a/graph-connector-app/README.md
+++ b/graph-connector-app/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Graph Connector Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 This sample app showcases how to build custom Graph Connector with Azure Functions and query data using Microsoft Graph Client and TeamsFx SDK.
 
 ![Graph Connector Overview](images/graph-connector-app-demo.gif)

--- a/graph-toolkit-contact-exporter/README.md
+++ b/graph-toolkit-contact-exporter/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Contact Exporter Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 Contact Exporter sample APP provides an easy way to export your teams contact info to Excel file. This APP is using [Microsoft Graph Toolkit](https://docs.microsoft.com/en-us/graph/toolkit/overview) as UI component. Please be advised that [mgt-teamsfx-provider](https://www.npmjs.com/package/@microsoft/mgt-teamsfx-provider) library is currently in preview stage, please expect breaking changes in the future release.
 
 ![Contact Exporter Overview](images/overview.gif)

--- a/graph-toolkit-one-productivity-hub/README.md
+++ b/graph-toolkit-one-productivity-hub/README.md
@@ -1,9 +1,5 @@
 # Getting Started with One Productivity Hub Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 One Productivity Hub sample shows you how to build a tab for viewing your calendar events, to-do tasks and files by using [Microsoft Graph Toolkit](https://docs.microsoft.com/en-us/graph/toolkit/overview) components and [TeamsFx Provider](https://www.npmjs.com/package/@microsoft/mgt-teamsfx-provider).
 
 ![One Productivity Hub Overview](images/oneproductivityhub-overview.gif)

--- a/graph-toolkit-productivity-hub-aspnetcore/README.md
+++ b/graph-toolkit-productivity-hub-aspnetcore/README.md
@@ -1,9 +1,5 @@
 # Getting Started with One Productivity Hub ASP.NET Core Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 One Productivity Hub sample shows you how to build a tab for viewing your calendar events, to-do tasks and files by using [Microsoft Graph Toolkit](https://docs.microsoft.com/en-us/graph/toolkit/overview) components and [MSAL2 Provider](https://docs.microsoft.com/en-us/graph/toolkit/providers/msal2).
 
 ![One Productivity Hub Overview](images/oneproductivityhub-overview-proxy.gif)

--- a/hello-world-tab-with-backend/README.md
+++ b/hello-world-tab-with-backend/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Hello World Tab with Backend Sample (Azure)
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->
-> This warning will be removed when the samples are ready for production.
-
 > Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 

--- a/hello-world-tab-without-sso/README.md
+++ b/hello-world-tab-without-sso/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Hello World Tab Without SSO Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->
-> This warning will be removed when the samples are ready for production.
-
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 
 Hello World Tab shows you how to build a tab app without single sign on.

--- a/hello-world-tab/README.md
+++ b/hello-world-tab/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Hello World Tab Sample (Azure)
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->
-> This warning will be removed when the samples are ready for production.
-
 > Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
 
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.

--- a/incoming-webhook-notification/README.md
+++ b/incoming-webhook-notification/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Incoming Webhook Notification Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 An Incoming Webhook Sample provides an easy way to send adaptive cards in Microsoft Teams channels. The webhooks are used as tools to track and notify.
 ![Incoming Webhook Overall](./images/incoming-webhook.gif)
 

--- a/share-now/README.md
+++ b/share-now/README.md
@@ -1,9 +1,5 @@
 # Getting Started With Share Now Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 Share Now promotes the exchange of information between colleagues by enabling users to share content within the Teams environment. Users engage the app to share items of interest and discover new shared content.
 
 ![Share Now](images/shareNow.gif)

--- a/stocks-update-notification-bot/README.md
+++ b/stocks-update-notification-bot/README.md
@@ -1,8 +1,5 @@
 # Stocks Update Notification Bot
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->
-
 Bots can be used to deliver pro-active messages into different Microsoft Teams contexts, such as a personal bot chat, one to one or group chat, or a channel conversation.
 
 The Stocks Update Notification bot shows you how to request data on a pretermined schedule from a public API using API Key authentication and render that data using an Adaptive Card in different Microsoft Teams contexts.

--- a/todo-list-SPFx/README.md
+++ b/todo-list-SPFx/README.md
@@ -1,9 +1,5 @@
 # Getting Started With Todo List Sample (SPFx)
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 `Todo List with SPFx` is a Todo List Manage tool for a group of people. This app is installed in Teams Team or Channel and hosted on SharePoint, members in the Team/Channel can collaborate on the same Todo List, manipulate the same set of Todo items. There is no requirement asking for an Azure account to deploy Azure resources to run this sample app.
 
 ![TodoList](images/ToDoListCRUD.gif)

--- a/todo-list-with-Azure-backend-M365/README.md
+++ b/todo-list-with-Azure-backend-M365/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Todo List Sample
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 Todo List app helps to manage your personal to do items. This app can be installed and used not only in your Teams client, but also Outlook client and Office.com. The frontend is a React app and the backend is an Azure Function. You can deploy and host the app in Azure.
 
 ![Todo Item List](images/todo-list-M365.gif)

--- a/todo-list-with-Azure-backend/README.md
+++ b/todo-list-with-Azure-backend/README.md
@@ -1,9 +1,5 @@
 # Getting Started with Todo List Sample (Azure)
 
-> Note: We really appreciate your feedback! If you encounter any issue or error, please report issues to us following the [Supporting Guide](./../SUPPORT.md). Meanwhile you can make [recording](https://aka.ms/teamsfx-record) of your journey with our product, they really make the product better. Thank you!
->  
-> This warning will be removed when the samples are ready for production.
-
 Todo List provides an easy way to manage to-do items in Teams Client. This app helps enabling task collaboration and management for your team. The frontend is a React app and the backend is hosted on Azure. You will need an Azure subscription to run the app.
 
 ![Todo Item List](images/ToDoListCRUD.gif)


### PR DESCRIPTION
Many Teams Toolkit samples include a public preview warning that should have been removed prior to the extension being generally available in May 2022. This PR removes those warnings.