### PR TITLE
Pins MGT to v2

### DIFF
--- a/graph-toolkit-productivity-hub-aspnetcore/OneProductivityHubAspNetCore/Pages/_Host.cshtml
+++ b/graph-toolkit-productivity-hub-aspnetcore/OneProductivityHubAspNetCore/Pages/_Host.cshtml
@@ -20,7 +20,7 @@
 </head>
 <body>
 
-    <script src="https://unpkg.com/@@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
 
     <script>
         mgt.Providers.globalProvider = new mgt.Msal2Provider({


### PR DESCRIPTION
Pins Microsoft Graph Toolkit CDN reference to v2 to avoid breaking sample when v3 will be released later this year.