### PR TITLE
Add `token.botframework.com` to validDomains

### DIFF
--- a/bot-sso/templates/appPackage/manifest.template.json
+++ b/bot-sso/templates/appPackage/manifest.template.json
@@ -65,7 +65,9 @@
         "identity",
         "messageTeamMembers"
     ],
-    "validDomains": [],
+    "validDomains": [
+        "token.botframework.com"
+    ],
     "webApplicationInfo": {
         "id": "{{state.fx-resource-aad-app-for-teams.clientId}}",
         "resource": "{{{state.fx-resource-aad-app-for-teams.applicationIdUris}}}"


### PR DESCRIPTION
# Description

According to [Marketplace Certification Policies](https://learn.microsoft.com/en-us/legal/marketplace/certification-policies#114033-external-domains) and [validation guidelines for the Teams Store](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/appsource/prepare/teams-store-validation-guidelines#external-domains), `validDomains` property of the teams manifest should contain the `token.botframework.com` value.

# Questions for the reviewers

- Why does it work without these domains being specified on the test tenant and during the local debugging? Do we have problem in documentation, or is it a problem in the differences between environments?
- The links above states two different domain addresses, one is with upper-case first letter and the second one with lower-case first letter. Is it case-sensitive?