### PR TITLE
chore: (v3) upgrade restify to support node 18

### DIFF
--- a/bot-sso/package.json
+++ b/bot-sso/package.json
@@ -29,12 +29,12 @@
     "botbuilder": "^4.15.0",
     "botbuilder-dialogs": "^4.15.0",
     "isomorphic-fetch": "^3.0.0",
-    "restify": "^8.5.1",
+    "restify": "^10.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",
     "nodemon": "^2.0.7",

--- a/command-bot-with-sso/bot/package.json
+++ b/command-bot-with-sso/bot/package.json
@@ -21,10 +21,10 @@
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.15.0",
         "isomorphic-fetch": "^3.0.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "copyfiles": "^2.4.1",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",

--- a/graph-connector-bot/bot/package.json
+++ b/graph-connector-bot/bot/package.json
@@ -29,13 +29,13 @@
     "isomorphic-fetch": "^3.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.1.4",
-    "restify": "^8.5.1",
+    "restify": "^10.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^18.11.9",
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7",
     "shx": "^0.3.3",

--- a/hello-world-bot-with-tab/bot/package.json
+++ b/hello-world-bot-with-tab/bot/package.json
@@ -23,11 +23,11 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.17.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "@types/node": "^14.0.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",

--- a/hello-world-bot/package.json
+++ b/hello-world-bot/package.json
@@ -23,11 +23,11 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.17.0",
-    "restify": "^8.5.1"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",
     "nodemon": "^2.0.7",

--- a/query-org-user-with-message-extension-sso/bot/package.json
+++ b/query-org-user-with-message-extension-sso/bot/package.json
@@ -22,10 +22,10 @@
     "@microsoft/teamsfx": "^2.0.0",
     "botbuilder": ">=4.15.0 <5.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "restify": "^8.5.1"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "copyfiles": "^2.4.1",
     "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7",

--- a/share-now/bot/package.json
+++ b/share-now/bot/package.json
@@ -23,7 +23,7 @@
         "axios": "^0.21.1",
         "botbuilder": "~4.11.0",
         "replace": "^1.2.0",
-        "restify": "~10.0.0",
+        "restify": "^10.0.0",
         "tedious": "^9.2.3"
     },
     "devDependencies": {

--- a/share-now/bot/package.json
+++ b/share-now/bot/package.json
@@ -23,11 +23,11 @@
         "axios": "^0.21.1",
         "botbuilder": "~4.11.0",
         "replace": "^1.2.0",
-        "restify": "~8.5.1",
+        "restify": "~10.0.0",
         "tedious": "^9.2.3"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "@types/tedious": "^4.0.3",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",


### PR DESCRIPTION
(This is for v3 branch)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16598471/
https://github.com/restify/node-restify/releases/tag/v10.0.0

Update all bot samples to use `restify:10` which supports node 18.