### PR TITLE
fix: fix restify bot (dev)

### DIFF
--- a/bot-sso/bot/index.ts
+++ b/bot-sso/bot/index.ts
@@ -69,7 +69,7 @@ server.post("/api/messages", async (req, res) => {
 });
 
 server.get(
-  "/auth-*.html",
+  "/auth-:name(start|end).html",
   restify.plugins.serveStatic({
     directory: path.join(__dirname, "public"),
   })

--- a/bot-sso/bot/tsconfig.json
+++ b/bot-sso/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/command-bot-with-sso/bot/src/index.ts
+++ b/command-bot-with-sso/bot/src/index.ts
@@ -27,7 +27,7 @@ server.post("/api/messages", async (req, res) => {
 });
 
 server.get(
-  "/auth-*.html",
+  "/auth-:name(start|end).html",
   restify.plugins.serveStatic({
     directory: path.join(__dirname, "public"),
   })

--- a/graph-connector-bot/bot/index.ts
+++ b/graph-connector-bot/bot/index.ts
@@ -77,7 +77,7 @@ server.post("/api/notification", async (req, res) => {
 });
 
 server.get(
-  "/auth-*.html",
+  "/auth-:name(start|end).html",
   restify.plugins.serveStatic({
     directory: path.join(__dirname, "public"),
   })

--- a/graph-connector-bot/bot/tsconfig.json
+++ b/graph-connector-bot/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/hello-world-bot/bot/tsconfig.json
+++ b/hello-world-bot/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/place-your-order-workflow-bot/bot/tsconfig.json
+++ b/place-your-order-workflow-bot/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/query-org-user-with-message-extension-sso/bot/index.ts
+++ b/query-org-user-with-message-extension-sso/bot/index.ts
@@ -59,6 +59,6 @@ server.post("/api/messages", async (req, res) => {
   });
 });
 
-server.get("/auth-*.html", restify.plugins.serveStatic({
+server.get("/auth-:name(start|end).html", restify.plugins.serveStatic({
   directory: path.join(__dirname, "public")
 }));

--- a/query-org-user-with-message-extension-sso/bot/tsconfig.json
+++ b/query-org-user-with-message-extension-sso/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/share-now/bot/tsconfig.json
+++ b/share-now/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",


### PR DESCRIPTION
(This is to dev barnch)

Related to https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16598471/
Use `es2017` in ts bot templates to ensure `async function` is kept during building, which is required by `restify:10`.
Update route as well to align with `restify:10`.