### PR TITLE
chore: remove TEAMS_APP_NAME env

### DIFF
--- a/adaptive-card-notification/appPackage/manifest.template.json
+++ b/adaptive-card-notification/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "adaptive-card-notification",
         "full": "full name for adaptive-card-notifi"
     },
     "description": {

--- a/adaptive-card-notification/appPackage/manifest.template.json
+++ b/adaptive-card-notification/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "adaptive-card-notification",
+        "short": "adaptive-card-notifi-${{TEAMSFX_ENV}}",
         "full": "full name for adaptive-card-notifi"
     },
     "description": {

--- a/adaptive-card-notification/teamsfx/app.local.yml
+++ b/adaptive-card-notification/teamsfx/app.local.yml
@@ -3,14 +3,14 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: adaptive-card-notifi-local # Teams app name
+      name: adaptive-card-notification # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 
 provision:
   - uses: botAadApp/create # Creates a new AAD app for bot if BOT_ID environment variable is empty
     with:
-      name: adaptive-card-notification
+      name: adaptive-card-notifi
     # Output: following environment variable will be persisted in current environment's .env file.
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot

--- a/adaptive-card-notification/teamsfx/app.local.yml
+++ b/adaptive-card-notification/teamsfx/app.local.yml
@@ -3,14 +3,14 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: adaptive-card-notifi-local # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 
 provision:
   - uses: botAadApp/create # Creates a new AAD app for bot if BOT_ID environment variable is empty
     with:
-      name: adaptive-card-notifi
+      name: adaptive-card-notification
     # Output: following environment variable will be persisted in current environment's .env file.
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot

--- a/adaptive-card-notification/teamsfx/app.local.yml
+++ b/adaptive-card-notification/teamsfx/app.local.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: adaptive-card-notification # Teams app name
+      name: adaptive-card-notifi-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/adaptive-card-notification/teamsfx/app.yml
+++ b/adaptive-card-notification/teamsfx/app.yml
@@ -38,7 +38,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: adaptive-card-notification # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/adaptive-card-notification/teamsfx/app.yml
+++ b/adaptive-card-notification/teamsfx/app.yml
@@ -38,7 +38,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: adaptive-card-notification # Teams app name
+      name: adaptive-card-notifi-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/bot-sso/appPackage/manifest.template.json
+++ b/bot-sso/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "sso-bot",
+        "short": "sso-bot-${{TEAMSFX_ENV}}",
         "full": "full name for sso-bot"
     },
     "description": {

--- a/bot-sso/teamsfx/app.local.yml
+++ b/bot-sso/teamsfx/app.local.yml
@@ -15,7 +15,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: sso-bot # Teams app name
+      name: sso-bot-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/bot-sso/teamsfx/app.yml
+++ b/bot-sso/teamsfx/app.yml
@@ -47,7 +47,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: sso-bot # Teams app name
+      name: sso-bot-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-bot-with-tab/appPackage/manifest.template.json
+++ b/hello-world-bot-with-tab/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "hello-world-bot-with-tab",
         "full": "Full name for hello-world-bot-with-tab"
     },
     "description": {

--- a/hello-world-in-meeting/appPackage/manifest.template.json
+++ b/hello-world-in-meeting/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "hello-world-in-meeting",
+        "short": "hello-world-in-meeting-${{TEAMSFX_ENV}}",
         "full": "Full name for hello-world-in-meeting"
     },
     "description": {

--- a/hello-world-in-meeting/appPackage/manifest.template.json
+++ b/hello-world-in-meeting/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "hello-world-in-meeting",
         "full": "Full name for hello-world-in-meeting"
     },
     "description": {

--- a/hello-world-in-meeting/teamsfx/app.local.yml
+++ b/hello-world-in-meeting/teamsfx/app.local.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: hello-world-in-meeting-local # Teams app name
+      name: hello-world-in-meeting-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-in-meeting/teamsfx/app.yml
+++ b/hello-world-in-meeting/teamsfx/app.yml
@@ -34,7 +34,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: hello-world-in-meeting
+      name: hello-world-in-meeting-${{TEAMSFX_ENV}}
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-tab-with-backend/appPackage/manifest.template.json
+++ b/hello-world-tab-with-backend/appPackage/manifest.template.json
@@ -15,12 +15,12 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
-        "full": "Full name for ${{TEAMS_APP_NAME}}"
+        "short": "hello-world-tab-with-backend",
+        "full": "Full name for hello-world-tab-with-backend"
     },
     "description": {
-        "short": "Short description of ${{TEAMS_APP_NAME}}",
-        "full": "Full description of ${{TEAMS_APP_NAME}}"
+        "short": "Short description of hello-world-tab-with-backend",
+        "full": "Full description of hello-world-tab-with-backend"
     },
     "accentColor": "#FFFFFF",
     "bots": [],

--- a/hello-world-tab-with-backend/appPackage/manifest.template.json
+++ b/hello-world-tab-with-backend/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "hello-world-tab-with-backend",
+        "short": "tab-with-backend-${{TEAMSFX_ENV}}",
         "full": "Full name for hello-world-tab-with-backend"
     },
     "description": {

--- a/hello-world-tab-with-backend/teamsfx/app.local.yml
+++ b/hello-world-tab-with-backend/teamsfx/app.local.yml
@@ -15,7 +15,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: hello-world-tab-with-backend # Teams app name
+      name: tab-with-backend-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-tab-with-backend/teamsfx/app.local.yml
+++ b/hello-world-tab-with-backend/teamsfx/app.local.yml
@@ -15,7 +15,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: hello-world-tab-with-backend # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-tab-with-backend/teamsfx/app.yml
+++ b/hello-world-tab-with-backend/teamsfx/app.yml
@@ -71,7 +71,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: hello-world-tab-with-backend # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/hello-world-tab-with-backend/teamsfx/app.yml
+++ b/hello-world-tab-with-backend/teamsfx/app.yml
@@ -71,7 +71,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: hello-world-tab-with-backend # Teams app name
+      name: tab-with-backend-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/query-org-user-with-message-extension-sso/appPackage/manifest.template.json
+++ b/query-org-user-with-message-extension-sso/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "query-org-user-with-me-sso",
         "full": "full name for query-org-user-with-me-sso"
     },
     "description": {

--- a/query-org-user-with-message-extension-sso/appPackage/manifest.template.json
+++ b/query-org-user-with-message-extension-sso/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "query-org-user-with-me-sso",
+        "short": "QueryOrgUserWithMESSO-${{TEAMSFX_ENV}}",
         "full": "full name for query-org-user-with-me-sso"
     },
     "description": {

--- a/query-org-user-with-message-extension-sso/teamsfx/app.local.yml
+++ b/query-org-user-with-message-extension-sso/teamsfx/app.local.yml
@@ -15,7 +15,7 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: QueryOrgUserWithMESSO # Teams app name
+      name: QueryOrgUserWithMESSO-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/query-org-user-with-message-extension-sso/teamsfx/app.yml
+++ b/query-org-user-with-message-extension-sso/teamsfx/app.yml
@@ -15,7 +15,7 @@ provision:
 
   - uses: botAadApp/create # Creates a new AAD app for Bot Registration.
     with:
-      name: QueryOrgUserWithMESSO
+      name: QueryOrgUserWithMESSO-${{TEAMSFX_ENV}}
     # Output: following environment variable will be persisted in current environment's .env file.
     # BOT_ID: the AAD app client id created for Bot Registration.
     # SECRET_BOT_PASSWORD: the AAD app client secret created for Bot Registration.

--- a/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/appPackage/manifest.template.json
+++ b/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "stocks-update-notif-bot",
         "full": "Full name for stocks-update-notif-bot"
     },
     "description": {

--- a/stocks-update-notification-bot/appPackage/manifest.template.json
+++ b/stocks-update-notification-bot/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "${{TEAMS_APP_NAME}}",
+        "short": "stocks-update-notif-bot",
         "full": "full name for stocks-update-notif-bot"
     },
     "description": {

--- a/stocks-update-notification-bot/appPackage/manifest.template.json
+++ b/stocks-update-notification-bot/appPackage/manifest.template.json
@@ -15,7 +15,7 @@
         "outline": "resources/outline.png"
     },
     "name": {
-        "short": "stocks-update-notif-bot",
+        "short": "stocks-update-notif-bot-${{TEAMSFX_ENV}}",
         "full": "full name for stocks-update-notif-bot"
     },
     "description": {

--- a/stocks-update-notification-bot/teamsfx/app.local.yml
+++ b/stocks-update-notification-bot/teamsfx/app.local.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: stocks-update-notif-bot # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/stocks-update-notification-bot/teamsfx/app.local.yml
+++ b/stocks-update-notification-bot/teamsfx/app.local.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: stocks-update-notif-bot # Teams app name
+      name: stocks-update-notif-bot-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/stocks-update-notification-bot/teamsfx/app.yml
+++ b/stocks-update-notification-bot/teamsfx/app.yml
@@ -38,7 +38,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: stocks-update-notif-bot # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/stocks-update-notification-bot/teamsfx/app.yml
+++ b/stocks-update-notification-bot/teamsfx/app.yml
@@ -38,7 +38,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: stocks-update-notif-bot # Teams app name
+      name: stocks-update-notif-bot-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/todo-list-SPFx/appPackage/manifest.template.json
+++ b/todo-list-SPFx/appPackage/manifest.template.json
@@ -11,7 +11,7 @@
         "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
     },
     "name": {
-        "short": "TodoListSPFx",
+        "short": "TodoListSPFx-${{TEAMSFX_ENV}}",
         "full": "Full name for TodoListSPFx"
     },
     "description": {

--- a/todo-list-SPFx/appPackage/manifest.template.local.json
+++ b/todo-list-SPFx/appPackage/manifest.template.local.json
@@ -11,7 +11,7 @@
         "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
     },
     "name": {
-        "short": "TodoListSPFx-local-debug",
+        "short": "TodoListSPFx-${{TEAMSFX_ENV}}",
         "full": "Full name for TodoListSPFx-local-debug"
     },
     "description": {

--- a/todo-list-SPFx/teamsfx/app.local.yml
+++ b/todo-list-SPFx/teamsfx/app.local.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: TodoListSPFx-local # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/todo-list-SPFx/teamsfx/app.yml
+++ b/todo-list-SPFx/teamsfx/app.yml
@@ -22,7 +22,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{TEAMS_APP_NAME}} # Teams app name
+      name: TodoListSPFx # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 

--- a/todo-list-SPFx/teamsfx/app.yml
+++ b/todo-list-SPFx/teamsfx/app.yml
@@ -22,7 +22,7 @@ deploy:
 registerApp:
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: TodoListSPFx # Teams app name
+      name: TodoListSPFx-${{TEAMSFX_ENV}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 


### PR DESCRIPTION
For samples, will use static name with ${{TEAMSFX_ENV}} suffix to differentiate local /dev app name.