### PR TITLE
chore(v3): add execPath for cli/runDotnetCommand in todo m365

### DIFF
--- a/todo-list-with-Azure-backend-M365/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.local.yml
@@ -69,6 +69,7 @@ deploy:
     with:
       args: build extensions.csproj -o ./bin --ignore-failed-sources
       workingDirectory: ./api
+      execPath: ${{DOTNET_PATH}}
 
   - uses: file/updateEnv # Generate runtime environment variables for tab
     with:

--- a/todo-list-with-Azure-backend-M365/teamsapp.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.yml
@@ -55,10 +55,6 @@ deploy:
       workingDirectory: api
       args: install
 
-  - uses: prerequisite/install # Install dependencies
-    with:
-      dotnet: true
-
   - uses: cli/runDotnetCommand
     with:
       workingDirectory: api


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17337112.