### PR TITLE
chore: remove botDomain in validDomains

### DIFF
--- a/adaptive-card-notification/appPackage/manifest.json
+++ b/adaptive-card-notification/appPackage/manifest.json
@@ -42,7 +42,5 @@
         "identity",
         "messageTeamMembers"
     ],
-    "validDomains": [
-        "${{BOT_DOMAIN}}"
-    ]
+    "validDomains": []
 }

--- a/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/appPackage/manifest.json
+++ b/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/appPackage/manifest.json
@@ -42,7 +42,5 @@
         "identity",
         "messageTeamMembers"
     ],
-    "validDomains": [
-        "${{BOT_DOMAIN}}"
-    ]
+    "validDomains": []
 }

--- a/stocks-update-notification-bot/appPackage/manifest.json
+++ b/stocks-update-notification-bot/appPackage/manifest.json
@@ -42,7 +42,5 @@
         "identity",
         "messageTeamMembers"
     ],
-    "validDomains": [
-        "${{BOT_DOMAIN}}"
-    ]
+    "validDomains": []
 }


### PR DESCRIPTION
detail: 
Xiaofu Huang[(P2) [adaptive-card-notification] check if "validDomain" in manifest can be removed](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17304210)
Xiaofu Huang[(P2) [stock-update-notification-bot-dotnet] check if "validDomain" in manifest can be removed](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17304470)
Xiaofu Huang[(P2) [stocks-update-notification-bot] check if "validDomain" in manifest can be removed](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17304480)