### PR TITLE
chore: avoid bot from debug wordings

### DIFF
--- a/NPM-search-connector-M365/.vscode/launch.json
+++ b/NPM-search-connector-M365/.vscode/launch.json
@@ -46,12 +46,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Edge)",
+            "name": "Launch App in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -60,12 +60,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -74,12 +74,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Edge)",
+            "name": "Launch App in Outlook (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -88,12 +88,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Chrome)",
+            "name": "Launch App in Outlook (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -102,7 +102,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -118,8 +118,8 @@
         {
             "name": "Debug in Teams (Edge)",
             "configurations": [
-                "Launch Bot in Teams (Edge)",
-                "Attach to Bot"
+                "Launch App in Teams (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -131,8 +131,8 @@
         {
             "name": "Debug in Teams (Chrome)",
             "configurations": [
-                "Launch Bot in Teams (Chrome)",
-                "Attach to Bot"
+                "Launch App in Teams (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -144,8 +144,8 @@
         {
             "name": "Debug in Outlook (Edge)",
             "configurations": [
-                "Launch Bot in Outlook (Edge)",
-                "Attach to Bot"
+                "Launch App in Outlook (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -157,8 +157,8 @@
         {
             "name": "Debug in Outlook (Chrome)",
             "configurations": [
-                "Launch Bot in Outlook (Chrome)",
-                "Attach to Bot"
+                "Launch App in Outlook (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/NPM-search-connector-M365/.vscode/tasks.json
+++ b/NPM-search-connector-M365/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -76,12 +76,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/adaptive-card-notification/.vscode/launch.json
+++ b/adaptive-card-notification/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/adaptive-card-notification/.vscode/tasks.json
+++ b/adaptive-card-notification/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -76,12 +76,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,
@@ -106,7 +100,7 @@
             },
             "dependsOn": [
                 "Start Azurite emulator",
-                "Watch bot"
+                "Compile typescript"
             ]
         },
         {
@@ -137,7 +131,7 @@
             }
         },
         {
-            "label": "Watch bot",
+            "label": "Compile typescript",
             "type": "shell",
             "command": "npm run watch:teamsfx",
             "isBackground": true,

--- a/adaptive-card-notification/src/columnsetNotificationHttpTrigger.ts
+++ b/adaptive-card-notification/src/columnsetNotificationHttpTrigger.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 import notificationTemplate from "./adaptiveCards/notification-columnset.json";
 import { ColumnsetData } from "./cardModels";
 
@@ -33,7 +33,7 @@ const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<ColumnsetData>(notificationTemplate).render(data)
     );

--- a/adaptive-card-notification/src/defaultNotificationHttpTrigger.ts
+++ b/adaptive-card-notification/src/defaultNotificationHttpTrigger.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
 
@@ -16,7 +16,7 @@ const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<CardData>(notificationTemplate).render(data)
     );

--- a/adaptive-card-notification/src/factsetNotificationHttpTrigger.ts
+++ b/adaptive-card-notification/src/factsetNotificationHttpTrigger.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 import notificationTemplate from "./adaptiveCards/notification-factset.json";
 import { FactsetData } from "./cardModels";
 
@@ -21,7 +21,7 @@ const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<FactsetData>(notificationTemplate).render(data)
     );

--- a/adaptive-card-notification/src/internal/initialize.ts
+++ b/adaptive-card-notification/src/internal/initialize.ts
@@ -3,7 +3,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create bot.
-export const bot = new ConversationBot({
+export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/adaptive-card-notification/src/internal/messageHandler.ts
+++ b/adaptive-card-notification/src/internal/messageHandler.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { bot } from "./initialize";
+import { notificationApp } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
 const httpTrigger: AzureFunction = async function (
@@ -7,7 +7,7 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  await notificationApp.requestHandler(req, res);
   return res.body;
 };
 

--- a/adaptive-card-notification/src/listNotificationHttpTrigger.ts
+++ b/adaptive-card-notification/src/listNotificationHttpTrigger.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 import notificationTemplate from "./adaptiveCards/notification-list.json";
 import { ListData } from "./cardModels";
 
@@ -21,7 +21,7 @@ const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<ListData>(notificationTemplate).render(data)
     );

--- a/adaptive-card-notification/src/mentionNotificationHttpTrigger.ts
+++ b/adaptive-card-notification/src/mentionNotificationHttpTrigger.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 import notificationTemplate from "./adaptiveCards/notification-mention.json";
 import { MentionData } from "./cardModels";
 
@@ -18,7 +18,7 @@ const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<MentionData>(notificationTemplate).render(data)
     );

--- a/bot-sso/.vscode/launch.json
+++ b/bot-sso/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/bot-sso/.vscode/tasks.json
+++ b/bot-sso/.vscode/tasks.json
@@ -27,8 +27,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -75,12 +75,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/command-bot-with-sso/.vscode/launch.json
+++ b/command-bot-with-sso/.vscode/launch.json
@@ -25,12 +25,12 @@
 
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -39,12 +39,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -53,7 +53,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/command-bot-with-sso/.vscode/tasks.json
+++ b/command-bot-with-sso/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -76,12 +76,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/graph-connector-bot/.vscode/launch.json
+++ b/graph-connector-bot/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/graph-connector-bot/.vscode/tasks.json
+++ b/graph-connector-bot/.vscode/tasks.json
@@ -27,8 +27,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/hello-world-bot-with-tab/.vscode/launch.json
+++ b/hello-world-bot-with-tab/.vscode/launch.json
@@ -29,7 +29,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -43,7 +43,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -69,7 +69,7 @@
             "name": "Debug (Edge)",
             "configurations": [
                 "Attach to Frontend (Edge)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -82,7 +82,7 @@
             "name": "Debug (Chrome)",
             "configurations": [
                 "Attach to Frontend (Chrome)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/query-org-user-with-message-extension-sso/.vscode/launch.json
+++ b/query-org-user-with-message-extension-sso/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/query-org-user-with-message-extension-sso/.vscode/tasks.json
+++ b/query-org-user-with-message-extension-sso/.vscode/tasks.json
@@ -27,8 +27,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -75,12 +75,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/stocks-update-notification-bot/.vscode/launch.json
+++ b/stocks-update-notification-bot/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/stocks-update-notification-bot/.vscode/tasks.json
+++ b/stocks-update-notification-bot/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -76,12 +76,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,
@@ -106,7 +100,7 @@
             },
             "dependsOn": [
                 "Start Azurite emulator",
-                "Watch bot"
+                "Compile typescript"
             ]
         },
         {
@@ -137,7 +131,7 @@
             }
         },
         {
-            "label": "Watch bot",
+            "label": "Compile typescript",
             "type": "shell",
             "command": "npm run watch:teamsfx",
             "isBackground": true,

--- a/stocks-update-notification-bot/src/internal/initialize.ts
+++ b/stocks-update-notification-bot/src/internal/initialize.ts
@@ -2,7 +2,7 @@ import { BotBuilderCloudAdapter } from "@microsoft/teamsfx";
 import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 
 // Create bot.
-export const bot = new ConversationBot({
+export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/stocks-update-notification-bot/src/internal/messageHandler.ts
+++ b/stocks-update-notification-bot/src/internal/messageHandler.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { bot } from "./initialize";
+import { notificationApp } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
 const httpTrigger: AzureFunction = async function (
@@ -7,7 +7,7 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<void> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  await notificationApp.requestHandler(req, res);
   return res.body;
 };
 

--- a/stocks-update-notification-bot/src/timerTrigger.ts
+++ b/stocks-update-notification-bot/src/timerTrigger.ts
@@ -4,7 +4,7 @@ import { AxiosInstance, BotBuilderCloudAdapter} from '@microsoft/teamsfx';
 import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import TeamsBotInstallation = BotBuilderCloudAdapter.TeamsBotInstallation;
 import { GlobalQuote } from './cardModels';
-import { bot } from './internal/initialize';
+import { notificationApp } from './internal/initialize';
 import template from './adaptiveCards/notification-default.json'
 import { alphaVantageClient } from './apiConnections/alphaVantage';
 
@@ -18,7 +18,7 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
     .then(quote => addTimestamp(quote)(timestamp))
     .then(quote => addCompanyName(quote)('Microsoft Corporation'))
     .then(quote =>
-      getInstallations(bot)
+      getInstallations(notificationApp)
         .then(targets => targets.map(target => sendCard(target)(AdaptiveCards)(template)(quote)))
     )
     .catch(err => handleError(err)(context));
@@ -73,8 +73,8 @@ const addCompanyName =
     (name: string): GlobalQuote => { return { ...quote, name } }
 
 const getInstallations =
-  (bot: ConversationBot): Promise<TeamsBotInstallation[]> =>
-    bot.notification.installations();
+  (app: ConversationBot): Promise<TeamsBotInstallation[]> =>
+    app.notification.installations();
 
 const sendCard =
   <T extends object>(target: TeamsBotInstallation) =>


### PR DESCRIPTION
Align with https://github.com/OfficeDev/TeamsFx/pull/7965, to
- Avoid using `bot` to describe the local service since it's just a web service, not limited to bot
- Using `notificationApp` instead of `bot` in source code, to align with other scenarios