### PR TITLE
fix: fix the photo error once user doese not have

### DIFF
--- a/query-org-user-with-message-extension-sso/teamsBot.ts
+++ b/query-org-user-with-message-extension-sso/teamsBot.ts
@@ -15,7 +15,7 @@ const oboAuthConfig: OnBehalfOfCredentialAuthConfig = {
   clientSecret: config.clientSecret,
 };
 
-const initialLoginEndpoint =`${config.botEndpoint}/auth-start.html`;
+const initialLoginEndpoint = `${config.botEndpoint}/auth-start.html`;
 
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
@@ -29,7 +29,7 @@ export class TeamsBot extends TeamsActivityHandler {
      * If query without token, no need to implement handleMessageExtensionQueryWithSSO;
      * Otherwise, just follow the sample code below to modify the user code.
      */
-    return await handleMessageExtensionQueryWithSSO(context, oboAuthConfig, initialLoginEndpoint, ['User.Read.All', 'User.Read'], 
+    return await handleMessageExtensionQueryWithSSO(context, oboAuthConfig, initialLoginEndpoint, ['User.Read.All', 'User.Read'],
       async (token: MessageExtensionTokenResponse) => {
         // User Code
 
@@ -38,18 +38,19 @@ export class TeamsBot extends TeamsActivityHandler {
         if (query.parameters[0] && query.parameters[0].name === 'initialRun') {
           const graphClient = createMicrosoftGraphClientWithCredential(credential, 'User.Read');
           const profile = await graphClient.api('/me').get();
-          let photoBinary;
+          let image = undefined;
           try {
-            photoBinary = await graphClient
+            let photoBinary = await graphClient
               .api("/me/photo/$value")
               .responseType(ResponseType.ARRAYBUFFER)
               .get();
+            const buffer = Buffer.from(photoBinary);
+            const imageUri = "data:image/png;base64," + buffer.toString("base64");
+            image = CardFactory.images([imageUri]);
           } catch (err) {
-            throw err;
+            console.error("This user may not have personal photo!", err.message);
           }
-          const buffer = Buffer.from(photoBinary);
-          const imageUri = "data:image/png;base64," + buffer.toString("base64");
-          const thumbnailCard = CardFactory.thumbnailCard(profile.displayName, profile.mail, CardFactory.images([imageUri]));
+          const thumbnailCard = CardFactory.thumbnailCard(profile.displayName, profile.mail, image ? image : "");
           attachments.push(thumbnailCard);
         } else {
           const graphClient = createMicrosoftGraphClientWithCredential(credential, 'User.Read.All');
@@ -58,19 +59,20 @@ export class TeamsBot extends TeamsActivityHandler {
             .header('ConsistencyLevel', 'eventual')
             .orderby('displayName')
             .get();
-          for(const user of users.value) {
-            let photoBinary;
+          for (const user of users.value) {
+            let image = undefined;
             try {
-              photoBinary = await graphClient
+              let photoBinary = await graphClient
                 .api(`/users/${user.id}/photo/$value`)
                 .responseType(ResponseType.ARRAYBUFFER)
                 .get();
+              const buffer = Buffer.from(photoBinary);
+              const imageUri = "data:image/png;base64," + buffer.toString("base64");
+              image = CardFactory.images([imageUri]);
             } catch (err) {
-              throw err;
+              console.error("This user may not have personal photo!", err.message)
             }
-            const buffer = Buffer.from(photoBinary);
-            const imageUri = "data:image/png;base64," + buffer.toString("base64");
-            const thumbnailCard = CardFactory.thumbnailCard(user.displayName, user.mail, CardFactory.images([imageUri]));
+            const thumbnailCard = CardFactory.thumbnailCard(user.displayName, user.mail, image ? image : "");
             attachments.push(thumbnailCard);
           }
         }


### PR DESCRIPTION

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17470758

User may not set personal photo, and get photo may failed, so to update the logic to return the result without photo if not exist.