### PR TITLE
chore: remove output comments

### DIFF
--- a/NPM-search-connector-M365/teamsapp.yml
+++ b/NPM-search-connector-M365/teamsapp.yml
@@ -26,7 +26,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/NPM-search-message-extension-codespaces/teamsapp.yml
+++ b/NPM-search-message-extension-codespaces/teamsapp.yml
@@ -30,7 +30,6 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/adaptive-card-notification/teamsapp.yml
+++ b/adaptive-card-notification/teamsapp.yml
@@ -26,7 +26,6 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/bot-sso/teamsapp.local.yml
+++ b/bot-sso/teamsapp.local.yml
@@ -41,8 +41,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/bot-sso/teamsapp.yml
+++ b/bot-sso/teamsapp.yml
@@ -39,14 +39,12 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
+
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/command-bot-with-sso/teamsapp.local.yml
+++ b/command-bot-with-sso/teamsapp.local.yml
@@ -41,8 +41,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/command-bot-with-sso/teamsapp.yml
+++ b/command-bot-with-sso/teamsapp.yml
@@ -38,14 +38,12 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
+
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/developer-assist-dashboard/teamsapp.local.yml
+++ b/developer-assist-dashboard/teamsapp.local.yml
@@ -34,8 +34,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/developer-assist-dashboard/teamsapp.yml
+++ b/developer-assist-dashboard/teamsapp.yml
@@ -32,21 +32,18 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
+
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/graph-connector-app/teamsapp.local.yml
+++ b/graph-connector-app/teamsapp.local.yml
@@ -38,8 +38,6 @@ provision:
     with:
       manifestPath: aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-connector-app/teamsapp.yml
+++ b/graph-connector-app/teamsapp.yml
@@ -32,21 +32,17 @@ provision:
           parameters: infra/azure.parameters.json # Relative path to teamsfx folder. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-connector-bot/teamsapp.local.yml
+++ b/graph-connector-bot/teamsapp.local.yml
@@ -40,8 +40,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-connector-bot/teamsapp.yml
+++ b/graph-connector-bot/teamsapp.yml
@@ -38,13 +38,12 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
+
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
+
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/graph-toolkit-contact-exporter/teamsapp.local.yml
+++ b/graph-toolkit-contact-exporter/teamsapp.local.yml
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-toolkit-contact-exporter/teamsapp.yml
+++ b/graph-toolkit-contact-exporter/teamsapp.yml
@@ -35,21 +35,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-toolkit-one-productivity-hub/teamsapp.local.yml
+++ b/graph-toolkit-one-productivity-hub/teamsapp.local.yml
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/graph-toolkit-one-productivity-hub/teamsapp.yml
+++ b/graph-toolkit-one-productivity-hub/teamsapp.yml
@@ -35,21 +35,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-    # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-    # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/hello-world-bot-with-tab/teamsapp.yml
+++ b/hello-world-bot-with-tab/teamsapp.yml
@@ -29,7 +29,6 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/teamsApp/validateManifest # Validate using manifest schema
     with:
@@ -53,7 +52,6 @@ provision:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
     # Triggered when 'teamsfx deploy' is executed
 deploy:

--- a/hello-world-in-meeting/teamsapp.yml
+++ b/hello-world-in-meeting/teamsapp.yml
@@ -19,14 +19,12 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to teamsfx folder. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/hello-world-tab-codespaces/teamsapp.yml
+++ b/hello-world-tab-codespaces/teamsapp.yml
@@ -23,14 +23,12 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/hello-world-tab-with-backend/teamsapp.local.yml
+++ b/hello-world-tab-with-backend/teamsapp.local.yml
@@ -44,8 +44,6 @@ provision:
     with:
       manifestPath: aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/hello-world-tab-with-backend/teamsapp.yml
+++ b/hello-world-tab-with-backend/teamsapp.yml
@@ -32,21 +32,17 @@ provision:
           parameters: infra/azure.parameters.json # Relative path to teamsfx folder. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
+++ b/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
@@ -22,14 +22,12 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab-and-addin # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/notification-codespaces/teamsapp.yml
+++ b/notification-codespaces/teamsapp.yml
@@ -30,7 +30,6 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/query-org-user-with-message-extension-sso/teamsapp.local.yml
+++ b/query-org-user-with-message-extension-sso/teamsapp.local.yml
@@ -41,8 +41,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
   
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/query-org-user-with-message-extension-sso/teamsapp.yml
+++ b/query-org-user-with-message-extension-sso/teamsapp.yml
@@ -39,13 +39,11 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
+
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/share-now/teamsapp.local.yml
+++ b/share-now/teamsapp.local.yml
@@ -50,8 +50,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/share-now/teamsapp.yml
+++ b/share-now/teamsapp.yml
@@ -39,21 +39,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID }}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before applying to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: the following environment variable(s) will be persisted in the current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/teamsapp.yml
+++ b/stocks-update-notification-bot-dotnet/StocksUpdateNotificationBot/teamsapp.yml
@@ -28,7 +28,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/stocks-update-notification-bot/teamsapp.yml
+++ b/stocks-update-notification-bot/teamsapp.yml
@@ -26,7 +26,6 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/team-central-dashboard/teamsapp.yml
+++ b/team-central-dashboard/teamsapp.yml
@@ -31,21 +31,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to teamsfx folder. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
     
   - uses: aadApp/update
     with:
       manifestPath: "./aad.manifest.json"
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/todo-list-with-Azure-backend-M365/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.local.yml
@@ -34,8 +34,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/todo-list-with-Azure-backend-M365/teamsapp.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.yml
@@ -32,21 +32,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID }}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/todo-list-with-Azure-backend/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend/teamsapp.local.yml
@@ -34,8 +34,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to teamsfx folder. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/todo-list-with-Azure-backend/teamsapp.yml
+++ b/todo-list-with-Azure-backend/teamsapp.yml
@@ -31,20 +31,17 @@ provision:
           parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
           deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID }}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
+
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:


### PR DESCRIPTION
Since we already have `writeToEnvironmentFile` field, the remaining output comments is no longer needed because they're explained in action's wiki page.

Impacts comments for below actions:
arm/deploy
aadApp/update
azureStorage/enableStaticWebsite