### PR TITLE
chore: update the link to app caching's section

### DIFF
--- a/hello-world-in-meeting/README.md
+++ b/hello-world-in-meeting/README.md
@@ -4,7 +4,7 @@ This App helps to enable your apps for Teams meetings and configure the apps to 
 
 ![side panel](/hello-world-in-meeting/images/sidepanel.png)
 
-> App Caching was configured in this sample to reduce the reload time of your app in a meeting. To learn about limitations and available scopes, please check [Enable app caching for your tab app](https://learn.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/build-tabs-for-meeting?tabs=desktop%2Cmeeting-chat-view-desktop%2Cmeeting-stage-view-desktop%2Cchannel-meeting-desktop#app-caching).
+> App Caching was configured in this sample to reduce the reload time of your app in a meeting. To learn about limitations and available scopes, please check [Enable app caching for your tab app](https://aka.ms/teamsfx-app-caching).
 
 ## This sample illustrates
 

--- a/hello-world-in-meeting/README.md
+++ b/hello-world-in-meeting/README.md
@@ -4,7 +4,7 @@ This App helps to enable your apps for Teams meetings and configure the apps to 
 
 ![side panel](/hello-world-in-meeting/images/sidepanel.png)
 
-> App Caching was configured in this sample to reduce the reload time of your app in a meeting. To learn about limitations and available scopes, please check [Enable app caching for your tab app](https://learn.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/app-caching-for-your-tab-app).
+> App Caching was configured in this sample to reduce the reload time of your app in a meeting. To learn about limitations and available scopes, please check [Enable app caching for your tab app](https://learn.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/build-tabs-for-meeting?tabs=desktop%2Cmeeting-chat-view-desktop%2Cmeeting-stage-view-desktop%2Cchannel-meeting-desktop#app-caching).
 
 ## This sample illustrates
 


### PR DESCRIPTION
It seems there's some changes related to the former link, so update the link with the new one to redirect developers to the app caching section.