### PR TITLE
fix: update yml and webpack for office add-in samples

### DIFF
--- a/hello-world-teams-tab-and-outlook-add-in/README.md
+++ b/hello-world-teams-tab-and-outlook-add-in/README.md
@@ -69,7 +69,7 @@ Once the provisioning and deployment steps are finished, you can preview your Ou
 
 To check that your manifest file is valid:
 
-- From Visual Studio Code: open the command palette and select: `Teams: Validate manifest file`.
+- From Visual Studio Code: open the command palette and select: `Teams: Validate Application` and select `Validate using manifest schema`.
 - From TeamsFx CLI: run command `teamsfx validate` in your project directory.
 
 ### Package

--- a/hello-world-teams-tab-and-outlook-add-in/add-in/webpack.config.js
+++ b/hello-world-teams-tab-and-outlook-add-in/add-in/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = async (env, options) => {
             to: "assets/[name][ext][query]",
           },
           {
-            from: "../build/appPackage/manifest*.json",
+            from: "../appPackage/build/manifest*.json",
             to: "[name]" + "[ext]",
             transform(content) {
               if (dev) {

--- a/hello-world-teams-tab-and-outlook-add-in/teamsapp.local.yml
+++ b/hello-world-teams-tab-and-outlook-add-in/teamsapp.local.yml
@@ -26,9 +26,6 @@ provision:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
       outputZipPath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
       outputJsonPath: ./appPackage/build/manifest.${{TEAMSFX_ENV}}.json
-  - uses: teamsApp/validateAppPackage # Validate app package using validation rules
-    with:
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.
   - uses: teamsApp/update # Apply the Teams app manifest to an existing Teams app in Teams Developer Portal. Will use the app id in manifest file to determine which Teams app to update.
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.

--- a/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
+++ b/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
@@ -86,3 +86,5 @@ publish:
   - uses: teamsApp/publishAppPackage # Publish the app to Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps) for review and approval
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
+      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID

--- a/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
+++ b/hello-world-teams-tab-and-outlook-add-in/teamsapp.yml
@@ -38,10 +38,6 @@ provision:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
       outputZipPath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
       outputJsonPath: ./appPackage/build/manifest.${{TEAMSFX_ENV}}.json
-  - uses: teamsApp/validateAppPackage # Validate app package using validation rules
-    with:
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.
-
   - uses: teamsApp/update # Apply the Teams app manifest to an existing Teams app in Teams Developer Portal. Will use the app id in manifest file to determine which Teams app to update.
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.
@@ -77,9 +73,6 @@ publish:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
       outputZipPath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
       outputJsonPath: ./appPackage/build/manifest.${{TEAMSFX_ENV}}.json
-  - uses: teamsApp/validateAppPackage # Validate app package using validation rules
-    with:
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.
   - uses: teamsApp/update # Apply the Teams app manifest to an existing Teams app in Teams Developer Portal. Will use the app id in manifest file to determine which Teams app to update.
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to this file. This is the path for built zip file.


### PR DESCRIPTION
For p0 bug:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17885411
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17900028

1) Update default path in webpack.config.js as the build output path has been changed from `./build/appPackage` to `./appPackage/build`

2) Update yml with writeToEnvironmentFile

3) Remove teamsApp/validateAppPackage from yml, as office-add in app uses another manifest schema. The server side doesn't accept "extensions" field.
![image](https://user-images.githubusercontent.com/71362691/230834569-9903b357-b42f-44f2-ace4-f8419c2cd92d.png)
