### PR TITLE
chore: remove pwa- from launch profiles

### DIFF
--- a/NPM-search-connector-M365/.vscode/launch.json
+++ b/NPM-search-connector-M365/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "presentation": {
@@ -47,7 +47,7 @@
         },
         {
             "name": "Launch App in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -61,7 +61,7 @@
         },
         {
             "name": "Launch App in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -75,7 +75,7 @@
         },
         {
             "name": "Launch App in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -89,7 +89,7 @@
         },
         {
             "name": "Launch App in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -103,7 +103,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/adaptive-card-notification/.vscode/launch.json
+++ b/adaptive-card-notification/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/bot-sso/.vscode/launch.json
+++ b/bot-sso/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/command-bot-with-sso/.vscode/launch.json
+++ b/command-bot-with-sso/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -26,7 +26,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -40,7 +40,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -54,7 +54,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/deep-linking-hello-world-tab-without-sso-M365/.vscode/launch.json
+++ b/deep-linking-hello-world-tab-without-sso-M365/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -13,7 +13,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -23,7 +23,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -33,7 +33,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/developer-assist-dashboard/.vscode/launch.json
+++ b/developer-assist-dashboard/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -47,7 +47,7 @@
         },
         {
             "name": "Launch Remote in the Microsoft 365 app (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {
@@ -58,7 +58,7 @@
         },
         {
             "name": "Launch Remote in the Microsoft 365 app (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {
@@ -69,7 +69,7 @@
         },
         {
             "name": "Attach to Frontend in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -80,7 +80,7 @@
         },
         {
             "name": "Attach to Frontend in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -91,7 +91,7 @@
         },
         {
             "name": "Attach to Frontend in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{local:M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -102,7 +102,7 @@
         },
         {
             "name": "Attach to Frontend in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{local:M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -113,7 +113,7 @@
         },
         {
             "name": "Attach to Frontend in the Microsoft 365 app (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{local:M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {
@@ -124,7 +124,7 @@
         },
         {
             "name": "Attach to Frontend in the Microsoft 365 app (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{local:M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {

--- a/graph-connector-app/.vscode/launch.json
+++ b/graph-connector-app/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Backend",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9229,
             "restart": true,

--- a/graph-connector-bot/.vscode/launch.json
+++ b/graph-connector-bot/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/graph-toolkit-contact-exporter/.vscode/launch.json
+++ b/graph-toolkit-contact-exporter/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/graph-toolkit-one-productivity-hub/.vscode/launch.json
+++ b/graph-toolkit-one-productivity-hub/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/hello-world-bot-with-tab/.vscode/launch.json
+++ b/hello-world-bot-with-tab/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/hello-world-in-meeting/.vscode/launch.json
+++ b/hello-world-in-meeting/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/hello-world-tab-with-backend/.vscode/launch.json
+++ b/hello-world-tab-with-backend/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Backend",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9229,
             "restart": true,

--- a/hello-world-teams-tab-and-outlook-add-in/.vscode/launch.json
+++ b/hello-world-teams-tab-and-outlook-add-in/.vscode/launch.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "Launch Remote in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -24,7 +24,7 @@
         },
         {
             "name": "Launch Remote in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -35,7 +35,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -46,7 +46,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/incoming-webhook-notification/.vscode/launch.json
+++ b/incoming-webhook-notification/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Attach to Incoming Webhook",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/query-org-user-with-message-extension-sso/.vscode/launch.json
+++ b/query-org-user-with-message-extension-sso/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/share-now/.vscode/launch.json
+++ b/share-now/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -40,7 +40,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -55,7 +55,7 @@
         },
         {
             "name": "Attach to Bot",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,
@@ -67,7 +67,7 @@
         },
         {
             "name": "Attach to Backend",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9229,
             "restart": true,

--- a/stocks-update-notification-bot/.vscode/launch.json
+++ b/stocks-update-notification-bot/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch App (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Launch App (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Local Service",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9239,
             "restart": true,

--- a/team-central-dashboard/.vscode/launch.json
+++ b/team-central-dashboard/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {

--- a/todo-list-SPFx/.vscode/launch.json
+++ b/todo-list-SPFx/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Hosted workbench (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://enter-your-SharePoint-site/_layouts/workbench.aspx",
             "webRoot": "${workspaceRoot}/SPFx",
@@ -27,7 +27,7 @@
         },
         {
             "name": "Hosted workbench (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://enter-your-SharePoint-site/_layouts/workbench.aspx",
             "webRoot": "${workspaceRoot}/SPFx",
@@ -51,7 +51,7 @@
         },
         {
             "name": "Start Teams workbench (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "webRoot": "${workspaceRoot}/SPFx",
@@ -70,7 +70,7 @@
         },
         {
             "name": "Start Teams workbench (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "webRoot": "${workspaceRoot}/SPFx",

--- a/todo-list-with-Azure-backend-M365/.vscode/launch.json
+++ b/todo-list-with-Azure-backend-M365/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Launch Remote in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{M365_APP_ID}}?${account-hint}",
             "presentation": {
@@ -47,7 +47,7 @@
         },
         {
             "name": "Launch Remote in the Microsoft 365 app (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {
@@ -58,7 +58,7 @@
         },
         {
             "name": "Launch Remote in the Microsoft 365 app (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{M365_APP_ID}}?auth=2&${account-hint}",
             "presentation": {
@@ -69,7 +69,7 @@
         },
         {
             "name": "Attach to Frontend in Teams (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -83,7 +83,7 @@
         },
         {
             "name": "Attach to Frontend in Teams (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -97,7 +97,7 @@
         },
         {
             "name": "Attach to Frontend in Outlook (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{local:M365_APP_ID}}?${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -111,7 +111,7 @@
         },
         {
             "name": "Attach to Frontend in Outlook (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://outlook.office.com/host/${{local:M365_APP_ID}}?${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -125,7 +125,7 @@
         },
         {
             "name": "Attach to Frontend in the Microsoft 365 app (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{local:M365_APP_ID}}?auth=2&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -139,7 +139,7 @@
         },
         {
             "name": "Attach to Frontend in the Microsoft 365 app (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://www.office.com/m365apps/${{local:M365_APP_ID}}?auth=2&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -153,7 +153,7 @@
         },
         {
             "name": "Attach to Backend",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9229,
             "restart": true,

--- a/todo-list-with-Azure-backend/.vscode/launch.json
+++ b/todo-list-with-Azure-backend/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -39,7 +39,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
@@ -53,7 +53,7 @@
         },
         {
             "name": "Attach to Backend",
-            "type": "pwa-node",
+            "type": "node",
             "request": "attach",
             "port": 9229,
             "restart": true,

--- a/whos-next-meeting-app/.vscode/launch.json
+++ b/whos-next-meeting-app/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Launch Remote (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -14,7 +14,7 @@
         },
         {
             "name": "Launch Remote (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -25,7 +25,7 @@
         },
         {
             "name": "Attach to Frontend (Edge)",
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "Attach to Frontend (Chrome)",
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {


### PR DESCRIPTION
To fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17943754/

Remove *pwa-* prefix from all launch profiles since it's deprecated.