### PR TITLE
fix: set env better format

### DIFF
--- a/developer-assist-dashboard/teamsapp.local.yml
+++ b/developer-assist-dashboard/teamsapp.local.yml
@@ -21,14 +21,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/graph-connector-app/teamsapp.local.yml
+++ b/graph-connector-app/teamsapp.local.yml
@@ -21,18 +21,12 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set required variables for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
-  - uses: script # Set FUNC_ENDPOINT for local launch
-    name: Set FUNC_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/graph-toolkit-contact-exporter/teamsapp.local.yml
+++ b/graph-toolkit-contact-exporter/teamsapp.local.yml
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/graph-toolkit-one-productivity-hub/teamsapp.local.yml
+++ b/graph-toolkit-one-productivity-hub/teamsapp.local.yml
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/hello-world-bot-with-tab/teamsapp.local.yml
+++ b/hello-world-bot-with-tab/teamsapp.local.yml
@@ -26,14 +26,11 @@ provision:
       channels:
         - name: msteams
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/hello-world-in-meeting/teamsapp.local.yml
+++ b/hello-world-in-meeting/teamsapp.local.yml
@@ -10,14 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/hello-world-tab-codespaces/teamsapp.local.yml
+++ b/hello-world-tab-codespaces/teamsapp.local.yml
@@ -10,14 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=${{CODESPACE_NAME}}-53000.${{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}}"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://${{CODESPACE_NAME}}-53000.${{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}}"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=${{CODESPACE_NAME}}-53000.${{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}}";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://${{CODESPACE_NAME}}-53000.${{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}}";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/hello-world-tab-with-backend/teamsapp.local.yml
+++ b/hello-world-tab-with-backend/teamsapp.local.yml
@@ -23,22 +23,13 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set required variables for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
-  - uses: script # Set FUNC_NAME for local launch
-    name: Set FUNC_NAME for local launch
-    with:
-      run: echo "::set-teamsfx-env FUNC_NAME=getUserProfile"
-  - uses: script # Set FUNC_ENDPOINT for local launch
-    name: Set FUNC_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env FUNC_NAME=getUserProfile";
+        echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/hello-world-teams-tab-and-outlook-add-in/teamsapp.local.yml
+++ b/hello-world-teams-tab-and-outlook-add-in/teamsapp.local.yml
@@ -10,15 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   # - uses: teamsApp/validateManifest # Validate using manifest schema
   #   with:

--- a/share-now/teamsapp.local.yml
+++ b/share-now/teamsapp.local.yml
@@ -37,14 +37,11 @@ provision:
       channels:
         - name: msteams
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/team-central-dashboard/teamsapp.local.yml
+++ b/team-central-dashboard/teamsapp.local.yml
@@ -20,22 +20,13 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID  
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set required variables for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
-  - uses: script # Set FUNC_NAME for local launch
-    name: Set FUNC_NAME for local launch
-    with:
-      run: echo "::set-teamsfx-env FUNC_NAME=finishTaskNotification"
-  - uses: script # Set FUNC_ENDPOINT for local launch
-    name: Set FUNC_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env FUNC_NAME=finishTaskNotification";
+        echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
         
   - uses: aadApp/update
     with:

--- a/todo-list-with-Azure-backend-M365/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.local.yml
@@ -21,14 +21,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/todo-list-with-Azure-backend/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend/teamsapp.local.yml
@@ -21,14 +21,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17884838/
Merge multiple `::set-teamsfx-env` to one action to make template clearer.
The semicolon(`;`) works as separator in both pwsh and bash which are the default shell of script action.