### PR TITLE
feat: no longer actively support node 14 in Teams Toolkit

### DIFF
--- a/NPM-search-connector-M365/README.md
+++ b/NPM-search-connector-M365/README.md
@@ -8,7 +8,7 @@ NPM Search Connector is a Message Extension that allows you to perform a quick s
 - How to use Teams Toolkit to build a message extension app that runs across Microsoft 365 including Teams and Outlook (Web)
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - [Set up your dev environment for extending Teams apps across Microsoft 365](https://aka.ms/teamsfx-m365-apps-prerequisites)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)

--- a/NPM-search-connector-M365/package.json
+++ b/NPM-search-connector-M365/package.json
@@ -2,7 +2,7 @@
   "name": "teams-messaging-extension",
   "version": "1.0.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "msteams": {
     "teamsAppId": null

--- a/NPM-search-message-extension-codespaces/package.json
+++ b/NPM-search-message-extension-codespaces/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Microsoft Teams Toolkit message extension Bot sample",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/adaptive-card-notification/README.md
+++ b/adaptive-card-notification/README.md
@@ -9,7 +9,7 @@ Adaptive Card Notification provides an easy way to send notification in Teams. T
 - How to send Adaptive Cards in Teams.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/adaptive-card-notification/infra/azure.bicep
+++ b/adaptive-card-notification/infra/azure.bicep
@@ -78,7 +78,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
         {
           name: 'BOT_ID'

--- a/adaptive-card-notification/package.json
+++ b/adaptive-card-notification/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Microsoft Teams Toolkit Adaptive Card Notification Bot Sample",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/bot-sso/README.md
+++ b/bot-sso/README.md
@@ -12,7 +12,7 @@ This is a sample chatbot application demonstrating Single Sign-on using `botbuil
 - Use TeamsFx SDK to implementing SSO for Teams bot.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/bot-sso/package.json
+++ b/bot-sso/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Microsoft Teams Toolkit sso bot sample",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/command-bot-with-sso/README.md
+++ b/command-bot-with-sso/README.md
@@ -20,7 +20,7 @@ This is a simple command bot that implements single sign-on feature to retrieve 
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/) version 14, 16, 18
+- [Node.js](https://nodejs.org/) version 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/command-bot-with-sso/package.json
+++ b/command-bot-with-sso/package.json
@@ -5,7 +5,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "main": "./lib/index.js",
     "scripts": {

--- a/deep-linking-hello-world-tab-without-sso-M365/README.md
+++ b/deep-linking-hello-world-tab-without-sso-M365/README.md
@@ -16,7 +16,7 @@ This sample app shows, how to use new Teams SDK V2 capabilities to simplify the 
 ![Hello World Deeplinking Tab](images/deeplink-without-SSO.gif)
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version after 4.0.0 or [TeamsFx CLI](https://aka.ms/teamsfx-cli) version after 0.10.2
 

--- a/deep-linking-hello-world-tab-without-sso-M365/package.json
+++ b/deep-linking-hello-world-tab-without-sso-M365/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "author": "",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/deep-linking-hello-world-tab-without-sso-M365/tabs/package.json
+++ b/deep-linking-hello-world-tab-without-sso-M365/tabs/package.json
@@ -2,7 +2,7 @@
   "name": "teamsfx-template-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/developer-assist-dashboard/README.md
+++ b/developer-assist-dashboard/README.md
@@ -15,7 +15,7 @@ Developer Assist Dashboard shows you how to build a tab with Azure DevOps work i
 
 ## Prerequisite to use this sample
 
-- [NodeJS](https://nodejs.org/), fully tested on NodeJS 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/developer-assist-dashboard/package.json
+++ b/developer-assist-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "dev-dashboard",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/graph-connector-app/README.md
+++ b/graph-connector-app/README.md
@@ -10,7 +10,7 @@ This sample app showcases how to build custom Graph Connector with Azure Functio
 - How to use Microsoft Graph API to build a custom Graph Connector.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit)

--- a/graph-connector-app/api/package.json
+++ b/graph-connector-app/api/package.json
@@ -2,7 +2,7 @@
     "name": "teamsfx-template-api",
     "version": "1.0.0",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",

--- a/graph-connector-app/infra/azure.bicep
+++ b/graph-connector-app/infra/azure.bicep
@@ -91,7 +91,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/graph-connector-app/package.json
+++ b/graph-connector-app/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "author": "",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/graph-connector-app/tabs/package.json
+++ b/graph-connector-app/tabs/package.json
@@ -2,7 +2,7 @@
   "name": "teamsfx-template-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/graph-connector-bot/README.md
+++ b/graph-connector-bot/README.md
@@ -10,7 +10,7 @@ This sample app showcases how to build a Teams command bot that queries custom d
 - How to use TeamsFx SDK to build bot to query data from Microsoft Graph connector.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - An Microsoft 365 account with admin permission. If you do not have M365 account, apply one from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit)

--- a/graph-connector-bot/package.json
+++ b/graph-connector-bot/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/graph-toolkit-contact-exporter/README.md
+++ b/graph-toolkit-contact-exporter/README.md
@@ -11,7 +11,7 @@ Graph Toolkit Contact Exporter sample APP provides an easy way to export your te
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/) version 14, 16, 18
+- [Node.js](https://nodejs.org/) version 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/graph-toolkit-contact-exporter/package.json
+++ b/graph-toolkit-contact-exporter/package.json
@@ -2,7 +2,7 @@
   "name": "graph-toolkit-contact-exporter",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/graph-toolkit-one-productivity-hub/README.md
+++ b/graph-toolkit-one-productivity-hub/README.md
@@ -11,7 +11,7 @@ One Productivity Hub sample shows you how to build a tab for viewing your calend
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/) version 14, 16, 18
+- [Node.js](https://nodejs.org/) version 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/graph-toolkit-one-productivity-hub/package.json
+++ b/graph-toolkit-one-productivity-hub/package.json
@@ -2,7 +2,7 @@
   "name": "one-productivity-hub",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/hello-world-bot-with-tab/README.md
+++ b/hello-world-bot-with-tab/README.md
@@ -10,7 +10,7 @@ This is a simple "Hello World" application that has both Bot and Tab capabilitie
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - An M365 account. If you do not have M365 account, apply one from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version after 4.0.0 or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/hello-world-bot-with-tab/bot/package.json
+++ b/hello-world-bot-with-tab/bot/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Microsoft Teams Toolkit hello world Bot sample",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "author": "Microsoft",
     "license": "MIT",

--- a/hello-world-bot-with-tab/package.json
+++ b/hello-world-bot-with-tab/package.json
@@ -4,7 +4,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/hello-world-bot-with-tab/tab/package.json
+++ b/hello-world-bot-with-tab/tab/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/hello-world-in-meeting/README.md
+++ b/hello-world-in-meeting/README.md
@@ -13,7 +13,7 @@ This App helps to enable your apps for Teams meetings and configure the apps to 
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Teams Toolkit for VS Code](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 - Follow the instruction to [create a meeting in Teams](https://support.microsoft.com/en-us/office/create-a-meeting-in-teams-for-personal-and-small-business-use-eb571219-517b-49bf-afe1-4fff091efa85). Then in the Calendar you can find the meeting you just created. Double click the meeting will open the meeting details, and will enable the meeting app to be added in this meeting in later steps.

--- a/hello-world-in-meeting/package.json
+++ b/hello-world-in-meeting/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world-in-meeting",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/hello-world-tab-codespaces/package.json
+++ b/hello-world-tab-codespaces/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/hello-world-tab-with-backend/README.md
+++ b/hello-world-tab-with-backend/README.md
@@ -16,7 +16,7 @@ Hello World Tab with Backend shows you how to build a tab app with an Azure Func
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/hello-world-tab-with-backend/api/README.md
+++ b/hello-world-tab-with-backend/api/README.md
@@ -4,7 +4,7 @@ Azure Functions are a great way to add server-side behaviors to any Teams applic
 
 ## Prerequisites
 
-- [NodeJS](https://nodejs.org/)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 
@@ -45,7 +45,7 @@ By default, Teams Toolkit and TeamsFx CLI will provision an Azure function app w
 - Sign in to [Azure Portal](https://azure.microsoft.com/).
 - Find your application's resource group and Azure Function app resource. The resource group name and the Azure function app name are stored in your project configuration file `.fx/env.*.json`. You can find them by searching the key `resourceGroupName` and `functionAppName` in that file.
 - After enter the home page of the Azure function app, you can find a navigation item called `Configuration` under `settings` group.
-- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~14` or `~16` according to your requirement.
+- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~16` or `~18` according to your requirement.
 - After Click `OK` button, don't forget to click `Save` button on the top of the page.
 
 Then following requests sent to the Azure function app will be handled by new node runtime version.

--- a/hello-world-tab-with-backend/api/package.json
+++ b/hello-world-tab-with-backend/api/package.json
@@ -2,7 +2,7 @@
     "name": "teamsfx-template-api",
     "version": "1.0.0",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",

--- a/hello-world-tab-with-backend/infra/azure.bicep
+++ b/hello-world-tab-with-backend/infra/azure.bicep
@@ -92,7 +92,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/hello-world-tab-with-backend/package.json
+++ b/hello-world-tab-with-backend/package.json
@@ -2,7 +2,7 @@
   "name": "teamsfx-template-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/hello-world-teams-tab-and-outlook-add-in/README.md
+++ b/hello-world-teams-tab-and-outlook-add-in/README.md
@@ -10,7 +10,7 @@ Now you have the ability to create a single unit of distribution for all your Mi
 
 ## Prerequisites to use this sample
 
-- [NodeJS](https://nodejs.org/en/): version 16 or 18.
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - Edge or Chrome installed for debugging Teams Tab. Edge installed for debugging Outlook add-in.
 - Outlook for Windows: Beta Channel, Build 16320 or higher. 
 - An M365 account. If you do not have M365 account, apply one from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)

--- a/hello-world-teams-tab-and-outlook-add-in/package.json
+++ b/hello-world-teams-tab-and-outlook-add-in/package.json
@@ -2,6 +2,9 @@
     "name": "tab-and-addin",
     "version": "0.0.1",
     "author": "Contoso",
+    "engines": {
+        "node": "16 || 18"
+    },
     "scripts": {
         "build:tab": "cd tab && npm run build",
         "build:add-in": "cd add-in && npm run build",

--- a/incoming-webhook-notification/README.md
+++ b/incoming-webhook-notification/README.md
@@ -7,7 +7,7 @@ An Incoming Webhook Sample provides an easy way to send adaptive cards in Micros
 - How to send Adaptive Cards in Teams.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A [Teams Channel](https://docs.microsoft.com/en-us/microsoftteams/teams-channels-overview)
 
 ## Minimal path to awesome

--- a/incoming-webhook-notification/package.json
+++ b/incoming-webhook-notification/package.json
@@ -4,7 +4,7 @@
   "description": "Microsoft Teams Toolkit Incoming Webhook Notification Sample",
   "author": "Microsoft",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "license": "MIT",
   "main": "./lib/index.js",

--- a/notification-codespaces/package.json
+++ b/notification-codespaces/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Microsoft Teams Toolkit Notification Bot Sample (Restify)",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "author": "Microsoft",
     "license": "MIT",

--- a/query-org-user-with-message-extension-sso/README.md
+++ b/query-org-user-with-message-extension-sso/README.md
@@ -8,7 +8,7 @@ This is a simple search-based message extension app demonstrating how to integra
 - How to use Microsoft Graph API to do query with SSO token in Message Extension
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/query-org-user-with-message-extension-sso/package.json
+++ b/query-org-user-with-message-extension-sso/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Microsoft Teams Toolkit message extension Bot sample",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "author": "Microsoft",
     "license": "MIT",

--- a/share-now/README.md
+++ b/share-now/README.md
@@ -11,7 +11,7 @@ Share Now promotes the exchange of information between colleagues by enabling us
 - How to connect to Azure SQL DB and how to do CRUD operations in DB.
 
 ## Prerequisite
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/share-now/api/package.json
+++ b/share-now/api/package.json
@@ -2,7 +2,7 @@
   "name": "teamsfx-sample-share-now-function",
   "version": "1.0.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "scripts": {
     "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",

--- a/share-now/bot/package.json
+++ b/share-now/bot/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",

--- a/share-now/infra/provision/function.bicep
+++ b/share-now/infra/provision/function.bicep
@@ -54,7 +54,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16'
+          value: '~18'
         }
       ]
     }

--- a/share-now/package.json
+++ b/share-now/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "author": "",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/share-now/tabs/package.json
+++ b/share-now/tabs/package.json
@@ -2,7 +2,7 @@
   "name": "share-now",
   "version": "1.0.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/stocks-update-notification-bot/README.md
+++ b/stocks-update-notification-bot/README.md
@@ -11,7 +11,7 @@ The Stocks Update Notification bot shows you how to request data on a pretermine
 - How to use a bot in different contexts
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/stocks-update-notification-bot/infra/azure.bicep
+++ b/stocks-update-notification-bot/infra/azure.bicep
@@ -81,7 +81,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
         {
           name: 'BOT_ID'

--- a/stocks-update-notification-bot/package.json
+++ b/stocks-update-notification-bot/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Stocks Update Notification bot",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "author": "Microsoft",
     "license": "MIT",

--- a/team-central-dashboard/README.md
+++ b/team-central-dashboard/README.md
@@ -15,7 +15,7 @@ Team Central Dashboard shows you how to build a tab with data chats and content 
 
 ## Prerequisite to use this sample
 
-- [NodeJS](https://nodejs.org/), fully tested on NodeJS 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 

--- a/team-central-dashboard/infra/azure.bicep
+++ b/team-central-dashboard/infra/azure.bicep
@@ -94,7 +94,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/team-central-dashboard/package.json
+++ b/team-central-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "team-central-dashboard",
   "version": "0.1.0",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "private": true,
   "dependencies": {

--- a/todo-list-with-Azure-backend-M365/README.md
+++ b/todo-list-with-Azure-backend-M365/README.md
@@ -10,7 +10,7 @@ Todo List app helps to manage your personal to do items. This app can be install
 - How to use Teams Toolkit to build a personal tab app with Azure Function backend that runs across Microsoft 365 including Teams, Outlook and the Microsoft 365 app.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - [Set up your dev environment for extending Teams apps across Microsoft 365](https://aka.ms/teamsfx-m365-apps-prerequisites)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)

--- a/todo-list-with-Azure-backend-M365/infra/provision/function.bicep
+++ b/todo-list-with-Azure-backend-M365/infra/provision/function.bicep
@@ -57,7 +57,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16' // Set NodeJS version to 16.x
+          value: '~18' // Set NodeJS version to 18.x
         }
       ]
       ftpsState: 'FtpsOnly'

--- a/todo-list-with-Azure-backend-M365/package.json
+++ b/todo-list-with-Azure-backend-M365/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "author": "",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "install:api": "cd api && npm install",

--- a/todo-list-with-Azure-backend/README.md
+++ b/todo-list-with-Azure-backend/README.md
@@ -13,7 +13,7 @@ Todo List provides an easy way to manage to-do items in Teams Client. This app h
 - How to use TeamsFx simple auth capability to get Teams user login information.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 14, 16, 18 (preview)
+- [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - Latest [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/todo-list-with-Azure-backend/api/package.json
+++ b/todo-list-with-Azure-backend/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "scripts": {
     "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",

--- a/todo-list-with-Azure-backend/infra/provision/function.bicep
+++ b/todo-list-with-Azure-backend/infra/provision/function.bicep
@@ -54,7 +54,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~16'
+          value: '~18'
         }
       ]
     }

--- a/todo-list-with-Azure-backend/package.json
+++ b/todo-list-with-Azure-backend/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "author": "",
     "engines": {
-        "node": "14 || 16 || 18"
+        "node": "16 || 18"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/todo-list-with-Azure-backend/tabs/package.json
+++ b/todo-list-with-Azure-backend/tabs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "16 || 18"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",


### PR DESCRIPTION
[Feature 17731849](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17731849): No longer actively support node 14 in Teams Toolkit

1. As of April 30th, 2023, Node 14 will reach the end of its lifecycle. [Detail](https://nodejs.dev/en/about/releases/)
2. The Azure Functions Core Tools now offer GA (General Availability) support for Node 18. [Detail](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-typescript#languages)