### PR TITLE
fix: update samples to support versioning func installation

### DIFF
--- a/adaptive-card-notification/.funcignore
+++ b/adaptive-card-notification/.funcignore
@@ -20,3 +20,4 @@ teamsapp.yml
 teamsapp.*.yml
 /env/
 /script/
+/devTools/

--- a/adaptive-card-notification/.gitignore
+++ b/adaptive-card-notification/.gitignore
@@ -31,3 +31,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+/devTools/

--- a/adaptive-card-notification/.vscode/tasks.json
+++ b/adaptive-card-notification/.vscode/tasks.json
@@ -85,7 +85,14 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/adaptive-card-notification/teamsapp.local.yml
+++ b/adaptive-card-notification/teamsapp.local.yml
@@ -45,7 +45,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
   - uses: cli/runNpmCommand # Run npm command

--- a/share-now/.gitignore
+++ b/share-now/.gitignore
@@ -19,3 +19,6 @@ lib
 .DS_Store
 .env
 .deployment
+
+# Dev tool directories
+/devTools/

--- a/share-now/.vscode/tasks.json
+++ b/share-now/.vscode/tasks.json
@@ -118,7 +118,14 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/share-now/teamsapp.local.yml
+++ b/share-now/teamsapp.local.yml
@@ -72,7 +72,9 @@ deploy:
     with:
       devCert:
         trust: true
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
       dotnet: true
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       sslCertFile: SSL_CRT_FILE

--- a/stocks-update-notification-bot/.funcignore
+++ b/stocks-update-notification-bot/.funcignore
@@ -20,3 +20,4 @@ teamsapp.yml
 teamsapp.*.yml
 /env/
 /script/
+/devTools/

--- a/stocks-update-notification-bot/.gitignore
+++ b/stocks-update-notification-bot/.gitignore
@@ -27,3 +27,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+/devTools/

--- a/stocks-update-notification-bot/.vscode/tasks.json
+++ b/stocks-update-notification-bot/.vscode/tasks.json
@@ -85,7 +85,14 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/stocks-update-notification-bot/teamsapp.local.yml
+++ b/stocks-update-notification-bot/teamsapp.local.yml
@@ -45,7 +45,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
   - uses: cli/runNpmCommand # Run npm command

--- a/todo-list-with-Azure-backend-M365/.gitignore
+++ b/todo-list-with-Azure-backend-M365/.gitignore
@@ -18,3 +18,6 @@ build
 .DS_Store
 .env
 .deployment
+
+# Dev tool directories
+/devTools/

--- a/todo-list-with-Azure-backend-M365/.vscode/tasks.json
+++ b/todo-list-with-Azure-backend-M365/.vscode/tasks.json
@@ -90,7 +90,14 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/todo-list-with-Azure-backend-M365/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend-M365/teamsapp.local.yml
@@ -64,7 +64,9 @@ deploy:
     with:
       devCert:
         trust: true
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
       dotnet: true
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       sslCertFile: SSL_CRT_FILE

--- a/todo-list-with-Azure-backend/.gitignore
+++ b/todo-list-with-Azure-backend/.gitignore
@@ -18,3 +18,6 @@ build
 .DS_Store
 .env
 .deployment
+
+# Dev tool directories
+/devTools/

--- a/todo-list-with-Azure-backend/.vscode/tasks.json
+++ b/todo-list-with-Azure-backend/.vscode/tasks.json
@@ -90,7 +90,14 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/todo-list-with-Azure-backend/teamsapp.local.yml
+++ b/todo-list-with-Azure-backend/teamsapp.local.yml
@@ -56,7 +56,9 @@ deploy:
     with:
       devCert:
         trust: true
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
       dotnet: true 
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       sslCertFile: SSL_CRT_FILE


### PR DESCRIPTION
Detail:
[Bug 17943760](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17943760): [V3] Replace "command:get-func-path" with soft link after support versioning installation
[Bug 17920588](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17920588): [V3] Support versioning install

Related to PR: https://github.com/OfficeDev/TeamsFx/pull/8482