### PR TITLE
docs: revert ttk version change for non-v5 sample

### DIFF
--- a/deep-linking-hello-world-tab-without-sso-M365/README.md
+++ b/deep-linking-hello-world-tab-without-sso-M365/README.md
@@ -18,7 +18,7 @@ This sample app shows, how to use new Teams SDK V2 capabilities to simplify the 
 
 - [Node.js](https://nodejs.org/), supported versions: 16, 18
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
-- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
+- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version after 4.0.0 or [TeamsFx CLI](https://aka.ms/teamsfx-cli) version after 0.10.2
 
 ## What you will learn in this sample:
 

--- a/whos-next-meeting-app/README.md
+++ b/whos-next-meeting-app/README.md
@@ -25,7 +25,7 @@ Then they used [Fluid Framework](https://fluidframework.com/docs/) to synchroniz
 
 - [NodeJS](https://nodejs.org/en/) version as required by Teams Toolkit (v14 or v16 at the time of this sample)
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. Please don't develop in production; you can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
-- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
+- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit)
 
 ## Version history
 


### PR DESCRIPTION
Revert the changes in https://github.com/OfficeDev/TeamsFx-Samples/pull/868. These samples are not support in V5.