### PR TITLE
docs: support resume codespace if it already exists

### DIFF
--- a/NPM-search-message-extension-codespaces/README.md
+++ b/NPM-search-message-extension-codespaces/README.md
@@ -1,6 +1,6 @@
 # Getting Started with NPM Search Message Extension Sample
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=basicLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fnpm-search-message-extension-codespaces%2Fdevcontainer.json)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=basicLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fnpm-search-message-extension-codespaces%2Fdevcontainer.json&resume=1)
 
 Search based message extensions allow you to query your service and post that information in the form of a card, right into your message. This sample allows you to perform a quick search to NPM Registry for a package and insert package details into conversations for sharing with your co-workers. 
 

--- a/hello-world-tab-codespaces/README.md
+++ b/hello-world-tab-codespaces/README.md
@@ -1,6 +1,6 @@
 # Getting Started with Hello World Tab Sample
 
-[![Open app in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=standardLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fhello-world-tab-codespaces%2Fdevcontainer.json)
+[![Open app in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=standardLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fhello-world-tab-codespaces%2Fdevcontainer.json&resume=1)
 
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 

--- a/notification-codespaces/README.md
+++ b/notification-codespaces/README.md
@@ -1,6 +1,6 @@
 # Getting Started with Notification Sample
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=basicLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fnotification-codespaces%2Fdevcontainer.json)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v3&repo=348288141&machine=basicLinux32gb&location=WestUs2&devcontainer_path=.devcontainer%2Fnotification-codespaces%2Fdevcontainer.json&resume=1)
 
 This sample showcases an app that send a message to Teams with Adaptive Cards triggered by a HTTP post request. You can further extend the sample to consume, transform and post events to individual, chat or channel in Teams.
 


### PR DESCRIPTION
Per feedback from Codespaces team, we can add `resume=1` to the `Open in GitHub Codespaces` badge. This will simplify the creation flow for users, and if they already have a Codespace from that repo and branch it'll prompt them to reuse their codespace instead of just creating a new codespace any single time.

### Already have a codespace for this repo and branch:

<img src="https://github.com/OfficeDev/TeamsFx-Samples/assets/10163840/e355a017-5902-44ef-93ed-4f21f0c732e1" width="50%" height="50%">

### No codespace for this repo and branch:

<img src="https://github.com/OfficeDev/TeamsFx-Samples/assets/10163840/d566fc42-8e05-46ab-93ac-4bbc5c13bacc" width="50%" height="50%">