### PR TITLE
chore: set v3 as release branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,4 +38,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           INITIAL_VERSION: ${{ steps.get-latest-tag.outputs.tag }}
-          
+          RELEASE_BRANCHES: "v3"


### PR DESCRIPTION
if not set v3 as release branch, will not push the new tag to repo
https://github.com/OfficeDev/TeamsFx-Samples/actions/runs/4955218556
once set, can push to repo