### PR TITLE
fix: Revert "fix: TTK is downloading sample from wrong tag url"

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -1,7 +1,7 @@
 {
-    "baseUrl": "https://github.com/OfficeDev/TeamsFx-Samples/tree/v2.2.0/",
-    "defaultPackageLink": "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/tags/v2.2.0.zip",
-    "baseFolderName": "TeamsFx-Samples-2.2.0",
+    "baseUrl": "https://github.com/OfficeDev/TeamsFx-Samples/tree/v2.1.0/",
+    "defaultPackageLink": "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/tags/v2.1.0.zip",
+    "baseFolderName": "TeamsFx-Samples-2.1.0",
     "samples": [
         {
             "id": "hello-world-tab-with-backend",


### PR DESCRIPTION
This reverts commit 94a8714455b2fc5080b480acf37dcb3202c4ccd6.
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24610557