### PR TITLE
feat: add TTK to recommended extension list for samples

### DIFF
--- a/NPM-search-connector-M365/.vscode/extensions.json
+++ b/NPM-search-connector-M365/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/NPM-search-message-extension-codespaces/.vscode/extensions.json
+++ b/NPM-search-message-extension-codespaces/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/adaptive-card-notification/.vscode/extensions.json
+++ b/adaptive-card-notification/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/bot-sso/.vscode/extensions.json
+++ b/bot-sso/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/command-bot-with-sso/.vscode/extensions.json
+++ b/command-bot-with-sso/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/developer-assist-dashboard/.vscode/extensions.json
+++ b/developer-assist-dashboard/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/graph-connector-app/.vscode/extensions.json
+++ b/graph-connector-app/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/graph-connector-bot/.vscode/extensions.json
+++ b/graph-connector-bot/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/graph-toolkit-contact-exporter/.vscode/extensions.json
+++ b/graph-toolkit-contact-exporter/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/graph-toolkit-one-productivity-hub/.vscode/extensions.json
+++ b/graph-toolkit-one-productivity-hub/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/hello-world-bot-with-tab/.vscode/extensions.json
+++ b/hello-world-bot-with-tab/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/hello-world-in-meeting/.vscode/extensions.json
+++ b/hello-world-in-meeting/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/hello-world-tab-codespaces/.vscode/extensions.json
+++ b/hello-world-tab-codespaces/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/hello-world-tab-with-backend/.vscode/extensions.json
+++ b/hello-world-tab-with-backend/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/hello-world-teams-tab-and-outlook-add-in/.vscode/extensions.json
+++ b/hello-world-teams-tab-and-outlook-add-in/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/incoming-webhook-notification/.vscode/extensions.json
+++ b/incoming-webhook-notification/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/live-share-dice-roller/.vscode/extensions.json
+++ b/live-share-dice-roller/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/notification-codespaces/.vscode/extensions.json
+++ b/notification-codespaces/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/query-org-user-with-message-extension-sso/.vscode/extensions.json
+++ b/query-org-user-with-message-extension-sso/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/share-now/.vscode/extensions.json
+++ b/share-now/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/stocks-update-notification-bot/.vscode/extensions.json
+++ b/stocks-update-notification-bot/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/team-central-dashboard/.vscode/extensions.json
+++ b/team-central-dashboard/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/teams-chef-bot/.vscode/extensions.json
+++ b/teams-chef-bot/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/todo-list-SPFx/.vscode/extensions.json
+++ b/todo-list-SPFx/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/todo-list-with-Azure-backend-M365/.vscode/extensions.json
+++ b/todo-list-with-Azure-backend-M365/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}

--- a/todo-list-with-Azure-backend/.vscode/extensions.json
+++ b/todo-list-with-Azure-backend/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "TeamsDevApp.ms-teams-vscode-extension"
+  ]
+}


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15649538/
When a user who has not installed TTK attempts to open a project created by TTK, we would like for them to receive the following notification from VS Code:
![image](https://github.com/OfficeDev/TeamsFx/assets/26134943/7c8d52e2-b102-41a9-b662-a395fa9cc96d)
