### PR TITLE
Live-share-dice-roller: Ensure all resources are closed when stopping a task

### DIFF
--- a/live-share-dice-roller/.vscode/launch.json
+++ b/live-share-dice-roller/.vscode/launch.json
@@ -10,7 +10,8 @@
                 "group": "remote",
                 "order": 1
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "postDebugTask": "Terminate All Tasks"
         },
         {
             "name": "Launch Remote (Chrome)",
@@ -21,7 +22,8 @@
                 "group": "remote",
                 "order": 2
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "postDebugTask": "Terminate All Tasks"
         },
         {
             "name": "Attach to Frontend (Edge)",
@@ -32,7 +34,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "postDebugTask": "Terminate All Tasks"
         },
         {
             "name": "Attach to Frontend (Chrome)",
@@ -43,7 +46,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "postDebugTask": "Terminate All Tasks"
         }
     ],
     "compounds": [

--- a/live-share-dice-roller/.vscode/tasks.json
+++ b/live-share-dice-roller/.vscode/tasks.json
@@ -103,6 +103,20 @@
                     "endsPattern": "ready|Failed|failed"
                 }
             }
+        },
+        {
+            "label": "Terminate All Tasks",
+            "command": "echo ${input:terminate}",
+            "type": "shell",
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "terminate",
+            "type": "command",
+            "command": "workbench.action.tasks.terminate",
+            "args": "terminateAll"
         }
     ]
 }


### PR DESCRIPTION
Received reports of http server not being closed when stopping, which prevents relaunching from working due to port 3000 already being used. PR ensures that all resources are closed when stopping the task.

https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/3261265