### PR TITLE
fix: no add to meeting button for live share sample

### DIFF
--- a/live-share-dice-roller/appPackage/manifest.json
+++ b/live-share-dice-roller/appPackage/manifest.json
@@ -32,6 +32,7 @@
                 "groupchat"
             ],
             "context": [
+                "meetingChatTab",
                 "meetingSidePanel",
                 "meetingStage"
             ]


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24833504