### PR TITLE
perf: support message extension sso for message extension

### DIFF
--- a/query-org-user-with-message-extension-sso/package.json
+++ b/query-org-user-with-message-extension-sso/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.2",
-        "@microsoft/teamsfx": "^2.0.0",
+        "@microsoft/teamsfx": "2.3.1-alpha.041c93f76.0",
         "botbuilder": ">=4.18.0 <5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "restify": "^10.0.0"

--- a/query-org-user-with-message-extension-sso/package.json
+++ b/query-org-user-with-message-extension-sso/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.2",
-        "@microsoft/teamsfx": "2.3.1-alpha.041c93f76.0",
+        "@microsoft/teamsfx": "2.3.1-beta.2023110805.0",
         "botbuilder": ">=4.18.0 <5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "restify": "^10.0.0"

--- a/query-org-user-with-message-extension-sso/teamsBot.ts
+++ b/query-org-user-with-message-extension-sso/teamsBot.ts
@@ -1,9 +1,10 @@
-import { TeamsActivityHandler, CardFactory, TurnContext } from "botbuilder";
+import { TeamsActivityHandler, CardFactory, TurnContext, AppBasedLinkQuery } from "botbuilder";
 import { ResponseType, Client } from "@microsoft/microsoft-graph-client";
 import { TokenCredentialAuthenticationProvider } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials";
 import {
   MessageExtensionTokenResponse,
   handleMessageExtensionQueryWithSSO,
+  handleMessageExtensionLinkQueryWithSSO,
   OnBehalfOfCredentialAuthConfig,
   OnBehalfOfUserCredential,
 } from "@microsoft/teamsfx";
@@ -102,6 +103,44 @@ export class TeamsBot extends TeamsActivityHandler {
         };
       }
     );
+  }
+
+  public async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<any> {
+    return await handleMessageExtensionLinkQueryWithSSO(context,
+      oboAuthConfig,
+      initialLoginEndpoint,
+      ["User.Read.All", "User.Read"],
+      async (token: MessageExtensionTokenResponse) => {
+        const credential = new OnBehalfOfUserCredential(
+          token.ssoToken,
+          oboAuthConfig
+        );
+        const attachments = [];
+        const authProvider = new TokenCredentialAuthenticationProvider(
+          credential,
+          {
+            scopes: ["User.Read"],
+          }
+        );
+        // Initialize Graph client instance with authProvider
+        const graphClient = Client.initWithMiddleware({
+          authProvider: authProvider,
+        });
+        const profile = await graphClient.api("/me").get();
+        await this.getUserPhotoWithGraphClient(
+          graphClient,
+          attachments,
+          profile,
+          `/me/photo/$value`
+        );
+        return {
+          composeExtension: {
+            type: "result",
+            attachmentLayout: "list",
+            attachments: attachments,
+          },
+        };
+      });
   }
 
   public async handleTeamsMessagingExtensionSelectItem(


### PR DESCRIPTION
current we implement `handleMessageExtensionLinkQueryWithSSO` to support the sso flow for link unfurling. 
this sample show how to leverage such API
![c11213](https://github.com/OfficeDev/TeamsFx-Samples/assets/75360946/400e0f9a-3233-4016-92ef-3ef407d30f4e)
you may modify the [domain](https://github.com/OfficeDev/TeamsFx-Samples/blob/cee7435879349635103eeaad79b77e51ee48583b/query-org-user-with-message-extension-sso/appPackage/manifest.json#L72) to enter the `handleTeamsAppBasedLinkQuery`