### PR TITLE
fix: thumbnail path for external sample

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -184,7 +184,7 @@
             ],
             "time": "5min to run",
             "configuration": "Ready for debug",
-            "thumbnailPath": "images/send-proactive-messages.gif",
+            "thumbnailPath": "images/thumbnail.png",
             "gifPath": "images/send-proactive-messages.gif",
             "suggested": false,
             "downloadUrlInfo": {


### PR DESCRIPTION
Related PR: https://github.com/OfficeDev/Microsoft-Teams-Samples/pull/960