### PR TITLE
fix: people picker placeholder was not fully displayed

### DIFF
--- a/graph-toolkit-contact-exporter/src/components/Tab.js
+++ b/graph-toolkit-contact-exporter/src/components/Tab.js
@@ -186,7 +186,6 @@ class Tab extends React.Component {
                   <PeoplePicker
                     userType="user"
                     selectionChanged={handleInputChange}
-                    placeholder="Typing name to select people to view contact info"
                   ></PeoplePicker>
                 </div>
 


### PR DESCRIPTION
[Bug 26020915](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26020915): [vsc] sample "connector exporter" placeholder text display incomplete

This is a bug of graph toolkit: https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/2915

