### PR TITLE
fix: teams chef bot use latest thumbnail

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -493,8 +493,8 @@
             ],
             "time": "5min to run",
             "configuration": "Ready for debug",
-            "thumbnailPath": "assets/TeamsChef002.jpg",
-            "gifPath": "assets/TeamsChef002.jpg",
+            "thumbnailPath": "assets/TeamsChef003.jpg",
+            "gifPath": "assets/TeamsChef003.jpg",
             "suggested": true,
             "downloadUrlInfo": {
                 "owner": "microsoft",


### PR DESCRIPTION
Related PR: https://github.com/microsoft/teams-ai/pull/1354