### PR TITLE
Update index.ts to use new default model

### DIFF
--- a/teams-chef-bot/src/index.ts
+++ b/teams-chef-bot/src/index.ts
@@ -79,7 +79,7 @@ type ApplicationTurnState = DefaultTurnState<ConversationState>;
 // Create AI components
 const planner = new OpenAIPlanner({
     apiKey: process.env.OPENAI_API_KEY,
-    defaultModel: 'text-davinci-003',
+    defaultModel: 'gpt-3.5-turbo',
     logRequests: true
 });
 const moderator = new OpenAIModerator({


### PR DESCRIPTION
using text-davinci-003 as the default model fails when running this with the error that the model has been deprecated. However, switching to gpt-3.5-turbo fixes it.