### PR TITLE
fix: teams-chef-bot thumbnail path

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -493,8 +493,8 @@
             ],
             "time": "5min to run",
             "configuration": "Ready for debug",
-            "thumbnailPath": "assets/TeamsChef003.jpg",
-            "gifPath": "assets/TeamsChef003.jpg",
+            "thumbnailPath": "assets/TeamsChef003.png",
+            "gifPath": "assets/TeamsChef003.png",
             "suggested": true,
             "downloadUrlInfo": {
                 "owner": "microsoft",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27192466