### PR TITLE
fix: add 'dev proxy' tag to sample and filter

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -17,7 +17,8 @@
             "SSO",
             "SPFx",
             "Outlook",
-            "Graph"
+            "Graph",
+            "Dev Proxy"
         ]
     },
     "samples": [
@@ -34,7 +35,8 @@
             "tags": [
                 "Tab",
                 "TS",
-                "Azure Functions"
+                "Azure Functions",
+                "Dev Proxy"
             ],
             "time": "5min to run",
             "configuration": "Ready for debug",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27355478